### PR TITLE
Feature/37 get roadmaps list user roadmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 .env.development.local
 .env.test.local
 .env.production.local
+cookies.txt
 
 # Testing
 coverage

--- a/apps/api/src/modules/roadmaps/dto/list-roadmaps-query.dto.ts
+++ b/apps/api/src/modules/roadmaps/dto/list-roadmaps-query.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class ListRoadmapsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  perPage?: number = 20;
+}

--- a/apps/api/src/modules/roadmaps/dto/roadmap-response.dto.ts
+++ b/apps/api/src/modules/roadmaps/dto/roadmap-response.dto.ts
@@ -1,3 +1,5 @@
+import type { RoleCategory } from '@repo/db/prisma/client';
+
 export interface PaginationMetaDto {
   page: number;
   perPage: number;
@@ -14,7 +16,7 @@ export interface RoadmapResponseDto {
   hoursPerDay: null | number;
   id: string;
   isTemplate: boolean;
-  roleCategory: string;
+  roleCategory: RoleCategory;
   title: string;
   updatedAt: string;
   userId: null | string;

--- a/apps/api/src/modules/roadmaps/dto/roadmap-response.dto.ts
+++ b/apps/api/src/modules/roadmaps/dto/roadmap-response.dto.ts
@@ -1,0 +1,26 @@
+export interface PaginationMetaDto {
+  page: number;
+  perPage: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface RoadmapResponseDto {
+  deadlineDate: null | string;
+  description: null | string;
+  estimatedWeeks: null | number;
+  generatedAt: string;
+  goalName: null | string;
+  hoursPerDay: null | number;
+  id: string;
+  isTemplate: boolean;
+  roleCategory: string;
+  title: string;
+  updatedAt: string;
+  userId: null | string;
+}
+
+export interface PaginatedRoadmapsResponseDto {
+  data: RoadmapResponseDto[];
+  meta: PaginationMetaDto;
+}

--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -1,13 +1,24 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
 
+import type { PaginatedRoadmapsResponseDto } from './dto/roadmap-response.dto';
+
 import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.decorator';
 import { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
+import { ListRoadmapsQueryDto } from './dto/list-roadmaps-query.dto';
 import { RoadmapNodesFilterDto } from './dto/roadmap-nodes-filter.dto';
 import { RoadmapsService } from './roadmaps.service';
 
 @Controller('roadmaps')
 export class RoadmapsController {
   constructor(private readonly roadmapsService: RoadmapsService) {}
+
+  @Get()
+  async listRoadmaps(
+    @CurrentUser() user: RequestUser,
+    @Query() query: ListRoadmapsQueryDto,
+  ): Promise<PaginatedRoadmapsResponseDto> {
+    return this.roadmapsService.listUserRoadmaps(user.id, query);
+  }
 
   /**
    * POST /roadmaps/generate

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -40,19 +40,6 @@ const ROADMAP_SELECT = {
   userId: true,
 } satisfies Prisma.RoadmapSelect;
 
-const ROLE_CATEGORY_WORD_LABELS: Record<string, string> = {
-  AI: 'AI',
-  AND: 'and',
-  BI: 'BI',
-  DEVOPS: 'DevOps',
-  DEVSECOPS: 'DevSecOps',
-  IOS: 'iOS',
-  MLOPS: 'MLOps',
-  POSTGRESQL: 'PostgreSQL',
-  QA: 'QA',
-  UX: 'UX',
-};
-
 type SelectedRoadmap = Pick<Roadmap, keyof typeof ROADMAP_SELECT>;
 
 type DecimalLike = {
@@ -87,7 +74,7 @@ export class RoadmapsService {
 
     const [roadmaps, total] = await this.prisma.$transaction([
       this.prisma.roadmap.findMany({
-        orderBy: { updatedAt: 'desc' },
+        orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
         select: ROADMAP_SELECT,
         skip,
         take: perPage,
@@ -571,7 +558,7 @@ export class RoadmapsService {
       hoursPerDay: this.formatDecimal(roadmap.hoursPerDay),
       id: roadmap.id,
       isTemplate: roadmap.isTemplate,
-      roleCategory: this.formatRoleCategory(roadmap.roleCategory),
+      roleCategory: roadmap.roleCategory,
       title: roadmap.title,
       updatedAt: roadmap.updatedAt.toISOString(),
       userId: roadmap.userId,
@@ -588,21 +575,6 @@ export class RoadmapsService {
     }
 
     return typeof value.toNumber === 'function' ? value.toNumber() : Number(value.toString());
-  }
-
-  private formatRoleCategory(roleCategory: string): string {
-    return roleCategory
-      .split('_')
-      .map((word) => {
-        const override = ROLE_CATEGORY_WORD_LABELS[word];
-
-        if (override) {
-          return override;
-        }
-
-        return word.charAt(0) + word.slice(1).toLowerCase();
-      })
-      .join(' ');
   }
 
   private stripMarkdownFences(text: string): string {

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { NodeType, type Prisma } from '@repo/db/prisma/client';
+import { NodeType, type Prisma, type Roadmap } from '@repo/db/prisma/client';
 
 import {
   DeadlineInPastException,
@@ -8,7 +8,9 @@ import {
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
 import type { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
+import type { ListRoadmapsQueryDto } from './dto/list-roadmaps-query.dto';
 import type { RoadmapNodesFilterDto } from './dto/roadmap-nodes-filter.dto';
+import type { PaginatedRoadmapsResponseDto, RoadmapResponseDto } from './dto/roadmap-response.dto';
 import type { AiNode, AiRoadmapOutput, FlatNode } from './types/ai-roadmap.types';
 import type { RoadmapNodesListResponse } from './types/roadmap-nodes.types';
 
@@ -23,6 +25,41 @@ const FEASIBILITY_THRESHOLD = 0.15;
 
 const LEAF_NODE_TYPES: NodeType[] = [NodeType.REQUIRED, NodeType.OPTIONAL];
 
+const ROADMAP_SELECT = {
+  deadlineDate: true,
+  description: true,
+  estimatedWeeks: true,
+  generatedAt: true,
+  goalName: true,
+  hoursPerDay: true,
+  id: true,
+  isTemplate: true,
+  roleCategory: true,
+  title: true,
+  updatedAt: true,
+  userId: true,
+} satisfies Prisma.RoadmapSelect;
+
+const ROLE_CATEGORY_WORD_LABELS: Record<string, string> = {
+  AI: 'AI',
+  AND: 'and',
+  BI: 'BI',
+  DEVOPS: 'DevOps',
+  DEVSECOPS: 'DevSecOps',
+  IOS: 'iOS',
+  MLOPS: 'MLOps',
+  POSTGRESQL: 'PostgreSQL',
+  QA: 'QA',
+  UX: 'UX',
+};
+
+type SelectedRoadmap = Pick<Roadmap, keyof typeof ROADMAP_SELECT>;
+
+type DecimalLike = {
+  toNumber?: () => number;
+  toString: () => string;
+};
+
 const toNumberOrNull = (value: Prisma.Decimal | number | null) =>
   value === null ? null : Number(value);
 
@@ -35,6 +72,40 @@ export class RoadmapsService {
     private readonly aiService: AiService,
     private readonly dagreLayout: DagreLayoutService,
   ) {}
+
+  async listUserRoadmaps(
+    userId: string,
+    query: ListRoadmapsQueryDto,
+  ): Promise<PaginatedRoadmapsResponseDto> {
+    const page = query.page ?? 1;
+    const perPage = query.perPage ?? 20;
+    const skip = (page - 1) * perPage;
+    const where = {
+      isTemplate: false,
+      userId,
+    } satisfies Prisma.RoadmapWhereInput;
+
+    const [roadmaps, total] = await this.prisma.$transaction([
+      this.prisma.roadmap.findMany({
+        orderBy: { updatedAt: 'desc' },
+        select: ROADMAP_SELECT,
+        skip,
+        take: perPage,
+        where,
+      }),
+      this.prisma.roadmap.count({ where }),
+    ]);
+
+    return {
+      data: roadmaps.map((roadmap) => this.formatRoadmap(roadmap)),
+      meta: {
+        page,
+        perPage,
+        total,
+        totalPages: Math.ceil(total / perPage),
+      },
+    };
+  }
 
   async listNodes(
     userId: string,
@@ -488,6 +559,50 @@ export class RoadmapsService {
     }
 
     return false;
+  }
+
+  private formatRoadmap(roadmap: SelectedRoadmap): RoadmapResponseDto {
+    return {
+      deadlineDate: this.formatDateOnly(roadmap.deadlineDate),
+      description: roadmap.description,
+      estimatedWeeks: roadmap.estimatedWeeks,
+      generatedAt: roadmap.generatedAt.toISOString(),
+      goalName: roadmap.goalName,
+      hoursPerDay: this.formatDecimal(roadmap.hoursPerDay),
+      id: roadmap.id,
+      isTemplate: roadmap.isTemplate,
+      roleCategory: this.formatRoleCategory(roadmap.roleCategory),
+      title: roadmap.title,
+      updatedAt: roadmap.updatedAt.toISOString(),
+      userId: roadmap.userId,
+    };
+  }
+
+  private formatDateOnly(date: Date | null): null | string {
+    return date ? date.toISOString().slice(0, 10) : null;
+  }
+
+  private formatDecimal(value: DecimalLike | null): null | number {
+    if (!value) {
+      return null;
+    }
+
+    return typeof value.toNumber === 'function' ? value.toNumber() : Number(value.toString());
+  }
+
+  private formatRoleCategory(roleCategory: string): string {
+    return roleCategory
+      .split('_')
+      .map((word) => {
+        const override = ROLE_CATEGORY_WORD_LABELS[word];
+
+        if (override) {
+          return override;
+        }
+
+        return word.charAt(0) + word.slice(1).toLowerCase();
+      })
+      .join(' ');
   }
 
   private stripMarkdownFences(text: string): string {

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -11,6 +11,7 @@ describe('RoadmapsController', () => {
   const mockRoadmapsService = {
     generate: jest.fn(),
     listNodes: jest.fn(),
+    listUserRoadmaps: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -49,5 +50,35 @@ describe('RoadmapsController', () => {
       q: 'REST',
     });
     expect(result).toEqual(mockResponse);
+  });
+
+  describe('listRoadmaps', () => {
+    it('should list roadmaps for current user', async () => {
+      const mockResponse = {
+        data: [],
+        meta: {
+          page: 1,
+          perPage: 20,
+          total: 0,
+          totalPages: 0,
+        },
+      };
+
+      mockRoadmapsService.listUserRoadmaps.mockResolvedValue(mockResponse);
+
+      const user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        fullName: 'Test User',
+        role: 'USER',
+        createdAt: new Date('2025-04-24T07:00:00Z'),
+      };
+      const query = { page: 2, perPage: 10 };
+
+      const result = await controller.listRoadmaps(user, query);
+
+      expect(mockRoadmapsService.listUserRoadmaps).toHaveBeenCalledWith('user-1', query);
+      expect(result).toEqual(mockResponse);
+    });
   });
 });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -35,30 +35,77 @@ function makeTxMock() {
   };
 }
 
+type TransactionMock = ReturnType<typeof makeTxMock>;
+type TransactionCallback = (tx: TransactionMock) => unknown;
+type AsyncMock<TResult = unknown, TArgs extends unknown[] = unknown[]> = jest.Mock<
+  Promise<TResult>,
+  TArgs
+>;
+
+interface RoadmapsPrismaMock {
+  $transaction: AsyncMock<unknown, [unknown]>;
+  roadmap: {
+    count: AsyncMock<number>;
+    findMany: AsyncMock<unknown[]>;
+  };
+  roadmapNode: {
+    findMany: AsyncMock<unknown[]>;
+  };
+  skill: {
+    findMany: AsyncMock<typeof MOCK_SKILLS>;
+  };
+  skillPrerequisite: {
+    findMany: AsyncMock<typeof MOCK_PRISMA_SKILL_PREREQUISITES>;
+  };
+}
+
+const createDecimal = (value: number) => ({
+  toNumber: () => value,
+  toString: () => value.toString(),
+});
+
+const createPrismaMock = (txMock: TransactionMock): RoadmapsPrismaMock => ({
+  $transaction: jest.fn<Promise<unknown>, [unknown]>().mockImplementation(async (input) => {
+    if (Array.isArray(input)) {
+      const transactionItems = input as Promise<unknown>[];
+
+      return Promise.all(transactionItems);
+    }
+
+    const transactionCallback = input as TransactionCallback;
+    return transactionCallback(txMock);
+  }),
+  roadmap: {
+    count: jest.fn<Promise<number>, unknown[]>(),
+    findMany: jest.fn<Promise<unknown[]>, unknown[]>(),
+  },
+  roadmapNode: { findMany: jest.fn<Promise<unknown[]>, unknown[]>() },
+  skill: {
+    findMany: jest.fn<Promise<typeof MOCK_SKILLS>, unknown[]>().mockResolvedValue(MOCK_SKILLS),
+  },
+  skillPrerequisite: {
+    findMany: jest
+      .fn<Promise<typeof MOCK_PRISMA_SKILL_PREREQUISITES>, unknown[]>()
+      .mockResolvedValue(MOCK_PRISMA_SKILL_PREREQUISITES),
+  },
+});
+
 describe('RoadmapsService', () => {
   let service: RoadmapsService;
-  let prisma: jest.Mocked<PrismaService>;
+  let prisma: RoadmapsPrismaMock;
   let aiService: jest.Mocked<AiService>;
   let dagreLayout: jest.Mocked<DagreLayoutService>;
 
   beforeEach(async () => {
     const txMock = makeTxMock();
+    const prismaMock = createPrismaMock(txMock);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RoadmapsService,
         {
           provide: PrismaService,
-          useValue: {
-            skill: { findMany: jest.fn().mockResolvedValue(MOCK_SKILLS) },
-            skillPrerequisite: {
-              findMany: jest.fn().mockResolvedValue(MOCK_PRISMA_SKILL_PREREQUISITES),
-            },
-            roadmapNode: { findMany: jest.fn() },
-            $transaction: jest
-              .fn()
-              .mockImplementation(async (fn: (tx: typeof txMock) => unknown) => await fn(txMock)),
-          },
+          useValue: prismaMock,
         },
         {
           provide: AiService,
@@ -74,7 +121,7 @@ describe('RoadmapsService', () => {
     }).compile();
 
     service = module.get<RoadmapsService>(RoadmapsService);
-    prisma = module.get(PrismaService);
+    prisma = prismaMock;
     aiService = module.get(AiService);
     dagreLayout = module.get(DagreLayoutService);
   });
@@ -376,7 +423,7 @@ describe('RoadmapsService', () => {
                 userId: MOCK_USER_ID,
               },
             },
-          }),
+          }) as unknown,
         }),
       );
     });
@@ -391,7 +438,7 @@ describe('RoadmapsService', () => {
           where: expect.objectContaining({
             roadmapId,
             name: { contains: 'REST', mode: 'insensitive' },
-          }),
+          }) as unknown,
         }),
       );
     });
@@ -404,6 +451,121 @@ describe('RoadmapsService', () => {
 
       expect(result).toEqual({ nodes: [] });
       expect(prisma.roadmapNode.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listUserRoadmaps', () => {
+    it('should return paginated current user roadmaps with mapped response fields', async () => {
+      const roadmap = {
+        deadlineDate: new Date('2025-10-01T00:00:00.000Z'),
+        description: 'A backend plan',
+        estimatedWeeks: null,
+        generatedAt: new Date('2025-04-24T07:00:00.000Z'),
+        goalName: 'Backend Intern at a product company',
+        hoursPerDay: createDecimal(2.5),
+        id: 'roadmap-1',
+        isTemplate: false,
+        roleCategory: 'BACKEND',
+        title: 'Your Backend Intern Roadmap',
+        updatedAt: new Date('2025-04-25T08:00:00.000Z'),
+        userId: 'user-1',
+      };
+
+      prisma.roadmap.findMany.mockResolvedValue([roadmap]);
+      prisma.roadmap.count.mockResolvedValue(42);
+
+      const result = await service.listUserRoadmaps('user-1', { page: 2, perPage: 10 });
+
+      expect(prisma.roadmap.findMany.mock.calls[0]?.[0]).toEqual({
+        orderBy: { updatedAt: 'desc' },
+        select: {
+          deadlineDate: true,
+          description: true,
+          estimatedWeeks: true,
+          generatedAt: true,
+          goalName: true,
+          hoursPerDay: true,
+          id: true,
+          isTemplate: true,
+          roleCategory: true,
+          title: true,
+          updatedAt: true,
+          userId: true,
+        },
+        skip: 10,
+        take: 10,
+        where: {
+          isTemplate: false,
+          userId: 'user-1',
+        },
+      });
+      expect(prisma.roadmap.count.mock.calls[0]?.[0]).toEqual({
+        where: {
+          isTemplate: false,
+          userId: 'user-1',
+        },
+      });
+      expect(result).toEqual({
+        data: [
+          {
+            deadlineDate: '2025-10-01',
+            description: 'A backend plan',
+            estimatedWeeks: null,
+            generatedAt: '2025-04-24T07:00:00.000Z',
+            goalName: 'Backend Intern at a product company',
+            hoursPerDay: 2.5,
+            id: 'roadmap-1',
+            isTemplate: false,
+            roleCategory: 'Backend',
+            title: 'Your Backend Intern Roadmap',
+            updatedAt: '2025-04-25T08:00:00.000Z',
+            userId: 'user-1',
+          },
+        ],
+        meta: {
+          page: 2,
+          perPage: 10,
+          total: 42,
+          totalPages: 5,
+        },
+      });
+    });
+
+    it('should use default pagination values', async () => {
+      prisma.roadmap.findMany.mockResolvedValue([]);
+      prisma.roadmap.count.mockResolvedValue(0);
+
+      const result = await service.listUserRoadmaps('user-1', {});
+
+      expect(prisma.roadmap.findMany.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({
+          skip: 0,
+          take: 20,
+        }),
+      );
+      expect(result.meta).toEqual({
+        page: 1,
+        perPage: 20,
+        total: 0,
+        totalPages: 0,
+      });
+    });
+
+    it('should return an empty data array when no roadmaps exist for the requested page', async () => {
+      prisma.roadmap.findMany.mockResolvedValue([]);
+      prisma.roadmap.count.mockResolvedValue(21);
+
+      const result = await service.listUserRoadmaps('user-1', { page: 4, perPage: 10 });
+
+      expect(result).toEqual({
+        data: [],
+        meta: {
+          page: 4,
+          perPage: 10,
+          total: 21,
+          totalPages: 3,
+        },
+      });
     });
   });
 });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -2,7 +2,7 @@
 import type { TestingModule } from '@nestjs/testing';
 
 import { Test } from '@nestjs/testing';
-import { NodeStatus, NodeType } from '@repo/db/prisma/client';
+import { NodeStatus, NodeType, RoleCategory } from '@repo/db/prisma/client';
 
 import {
   DeadlineInPastException,
@@ -465,7 +465,7 @@ describe('RoadmapsService', () => {
         hoursPerDay: createDecimal(2.5),
         id: 'roadmap-1',
         isTemplate: false,
-        roleCategory: 'BACKEND',
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
         title: 'Your Backend Intern Roadmap',
         updatedAt: new Date('2025-04-25T08:00:00.000Z'),
         userId: 'user-1',
@@ -477,7 +477,7 @@ describe('RoadmapsService', () => {
       const result = await service.listUserRoadmaps('user-1', { page: 2, perPage: 10 });
 
       expect(prisma.roadmap.findMany.mock.calls[0]?.[0]).toEqual({
-        orderBy: { updatedAt: 'desc' },
+        orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
         select: {
           deadlineDate: true,
           description: true,
@@ -516,7 +516,7 @@ describe('RoadmapsService', () => {
             hoursPerDay: 2.5,
             id: 'roadmap-1',
             isTemplate: false,
-            roleCategory: 'Backend',
+            roleCategory: RoleCategory.WEB_DEVELOPMENT,
             title: 'Your Backend Intern Roadmap',
             updatedAt: '2025-04-25T08:00:00.000Z',
             userId: 'user-1',


### PR DESCRIPTION

## Description

- Adds the `GET /roadmaps` API endpoint to return a paginated list of roadmaps owned by the authenticated user.
- The endpoint filters results by the current user, excludes template roadmaps, supports `page` and `perPage` query params, and returns a `{ data, meta }` response matching the API contract. It also includes response mapping for roadmap fields and unit tests for the controller and service.


## Related Issue 

Closes #37 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added `GET /roadmaps` endpoint for authenticated users.
- Filters roadmaps by current user and excludes templates.
- Added pagination support with `page` and `perPage`, defaulting to `page=1` and `perPage=20`.
- Added response mapper for roadmap fields, including enum, decimal, and date formatting.
- Registered `RoadmapsModule` in the API app module.
- Added unit tests for roadmaps controller and service.


## How to Test

Steps to verify:

1. Run API tests:    `pnpm --filter api test`
2. Run API build: `pnpm --filter api build`
3. Manually verify the endpoint

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

- This implementation is based on the API spec dated April 29.
- Reviewers should note that `GET /roadmaps` is protected and requires an authenticated cookie. The endpoint currently lists only user-owned non-template roadmaps and returns an empty `data` array when the user has no roadmaps.


