### PR TITLE
Feature/38 Implement controller and service for managing roadmaps

### DIFF
--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -1,6 +1,16 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
 
-import type { PaginatedRoadmapsResponseDto } from './dto/roadmap-response.dto';
+import type { PaginatedRoadmapsResponseDto, RoadmapResponseDto } from './dto/roadmap-response.dto';
 
 import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.decorator';
 import { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
@@ -47,14 +57,17 @@ export class RoadmapsController {
     return this.roadmapsService.listNodes(user.id, roadmapId, query);
   }
 
-  @Get(':id')
-  async get(@CurrentUser() user: RequestUser, @Param('id') id: string) {
-    return this.service.getByIdForOwner(user.id, id);
+  @Get(':roadmapId')
+  async get(
+    @CurrentUser() user: RequestUser,
+    @Param('roadmapId') roadmapId: string,
+  ): Promise<RoadmapResponseDto> {
+    return this.roadmapsService.getByIdForOwner(user.id, roadmapId);
   }
 
-  @Delete(':id')
-  @HttpCode(204)
-  async remove(@CurrentUser() user: RequestUser, @Param('id') id: string) {
-    await this.service.deleteByIdForOwner(user.id, id);
+  @Delete(':roadmapId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@CurrentUser() user: RequestUser, @Param('roadmapId') roadmapId: string) {
+    await this.roadmapsService.deleteByIdForOwner(user.id, roadmapId);
   }
 }

--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -46,4 +46,15 @@ export class RoadmapsController {
   ) {
     return this.roadmapsService.listNodes(user.id, roadmapId, query);
   }
+
+  @Get(':id')
+  async get(@CurrentUser() user: RequestUser, @Param('id') id: string) {
+    return this.service.getByIdForOwner(user.id, id);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  async remove(@CurrentUser() user: RequestUser, @Param('id') id: string) {
+    await this.service.deleteByIdForOwner(user.id, id);
+  }
 }

--- a/apps/api/src/modules/roadmaps/roadmaps.module.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.module.ts
@@ -1,14 +1,11 @@
 import { Module } from '@nestjs/common';
 
-import { AiModule } from '../ai/ai.module';
-import { PrismaModule } from '../prisma/prisma.module';
-import { DagreLayoutService } from './dagre-layout.service';
 import { RoadmapsController } from './roadmaps.controller';
 import { RoadmapsService } from './roadmaps.service';
 
 @Module({
-  imports: [AiModule, PrismaModule],
   controllers: [RoadmapsController],
-  providers: [RoadmapsService, DagreLayoutService],
+  providers: [RoadmapsService],
+  exports: [RoadmapsService],
 })
 export class RoadmapsModule {}

--- a/apps/api/src/modules/roadmaps/roadmaps.module.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.module.ts
@@ -1,11 +1,15 @@
 import { Module } from '@nestjs/common';
 
+import { AiModule } from '../ai/ai.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { DagreLayoutService } from './dagre-layout.service';
 import { RoadmapsController } from './roadmaps.controller';
 import { RoadmapsService } from './roadmaps.service';
 
 @Module({
+  imports: [AiModule, PrismaModule],
   controllers: [RoadmapsController],
-  providers: [RoadmapsService],
+  providers: [RoadmapsService, DagreLayoutService],
   exports: [RoadmapsService],
 })
 export class RoadmapsModule {}

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -587,4 +587,29 @@ export class RoadmapsService {
     }
     return trimmed;
   }
+
+  async getByIdForOwner(userId: string, roadmapId: string) {
+    const roadmap = await this.prisma.roadmap.findUnique({
+      where: { id: roadmapId },
+    });
+
+    if (!roadmap || roadmap.userId !== userId) {
+      throw new RoadmapNotFoundException(roadmapId);
+    }
+
+    return roadmap;
+  }
+
+  async deleteByIdForOwner(userId: string, roadmapId: string) {
+    const roadmap = await this.prisma.roadmap.findUnique({
+      where: { id: roadmapId },
+      select: { id: true, userId: true },
+    });
+
+    if (!roadmap || roadmap.userId !== userId) {
+      throw new RoadmapNotFoundException(roadmapId);
+    }
+
+    await this.prisma.$transaction([this.prisma.roadmap.delete({ where: { id: roadmapId } })]);
+  }
 }

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -4,6 +4,7 @@ import { NodeType, type Prisma, type Roadmap } from '@repo/db/prisma/client';
 import {
   DeadlineInPastException,
   RoadmapGenerationUnavailableException,
+  RoadmapNotFoundException,
 } from '@/common/exceptions/app.exceptions';
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
@@ -588,28 +589,34 @@ export class RoadmapsService {
     return trimmed;
   }
 
-  async getByIdForOwner(userId: string, roadmapId: string) {
-    const roadmap = await this.prisma.roadmap.findUnique({
-      where: { id: roadmapId },
+  async getByIdForOwner(userId: string, roadmapId: string): Promise<RoadmapResponseDto> {
+    const roadmap = await this.prisma.roadmap.findFirst({
+      select: ROADMAP_SELECT,
+      where: {
+        id: roadmapId,
+        isTemplate: false,
+        userId,
+      },
     });
 
-    if (!roadmap || roadmap.userId !== userId) {
+    if (!roadmap) {
       throw new RoadmapNotFoundException(roadmapId);
     }
 
-    return roadmap;
+    return this.formatRoadmap(roadmap);
   }
 
-  async deleteByIdForOwner(userId: string, roadmapId: string) {
-    const roadmap = await this.prisma.roadmap.findUnique({
-      where: { id: roadmapId },
-      select: { id: true, userId: true },
+  async deleteByIdForOwner(userId: string, roadmapId: string): Promise<void> {
+    const result = await this.prisma.roadmap.deleteMany({
+      where: {
+        id: roadmapId,
+        isTemplate: false,
+        userId,
+      },
     });
 
-    if (!roadmap || roadmap.userId !== userId) {
+    if (result.count === 0) {
       throw new RoadmapNotFoundException(roadmapId);
     }
-
-    await this.prisma.$transaction([this.prisma.roadmap.delete({ where: { id: roadmapId } })]);
   }
 }

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -9,7 +9,9 @@ describe('RoadmapsController', () => {
   let controller: RoadmapsController;
 
   const mockRoadmapsService = {
+    deleteByIdForOwner: jest.fn(),
     generate: jest.fn(),
+    getByIdForOwner: jest.fn(),
     listNodes: jest.fn(),
     listUserRoadmaps: jest.fn(),
   };
@@ -79,6 +81,58 @@ describe('RoadmapsController', () => {
 
       expect(mockRoadmapsService.listUserRoadmaps).toHaveBeenCalledWith('user-1', query);
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('get', () => {
+    it('should get a roadmap for the current user', async () => {
+      const user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        fullName: 'Test User',
+        role: 'USER',
+        createdAt: new Date('2025-04-24T07:00:00Z'),
+      };
+      const response = {
+        deadlineDate: null,
+        description: 'A backend plan',
+        estimatedWeeks: null,
+        generatedAt: '2025-04-24T07:00:00.000Z',
+        goalName: null,
+        hoursPerDay: null,
+        id: 'roadmap-1',
+        isTemplate: false,
+        roleCategory: 'WEB_DEVELOPMENT',
+        title: 'Backend roadmap',
+        updatedAt: '2025-04-25T08:00:00.000Z',
+        userId: 'user-1',
+      };
+
+      mockRoadmapsService.getByIdForOwner.mockResolvedValue(response);
+
+      const result = await controller.get(user, 'roadmap-1');
+
+      expect(mockRoadmapsService.getByIdForOwner).toHaveBeenCalledWith('user-1', 'roadmap-1');
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a roadmap for the current user and return no body', async () => {
+      const user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        fullName: 'Test User',
+        role: 'USER',
+        createdAt: new Date('2025-04-24T07:00:00Z'),
+      };
+
+      mockRoadmapsService.deleteByIdForOwner.mockResolvedValue(undefined);
+
+      const result = await controller.remove(user, 'roadmap-1');
+
+      expect(mockRoadmapsService.deleteByIdForOwner).toHaveBeenCalledWith('user-1', 'roadmap-1');
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -569,3 +569,141 @@ describe('RoadmapsService', () => {
     });
   });
 });
+
+describe('RoadmapsService', () => {
+  let service: RoadmapsService;
+  let prismaService: {
+    roadmap: {
+      findUnique: jest.Mock;
+      delete: jest.Mock;
+    };
+    roadmapNode: {
+      deleteMany: jest.Mock;
+    };
+    userNodeProgress: {
+      deleteMany: jest.Mock;
+    };
+    $transaction: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    prismaService = {
+      roadmap: {
+        findUnique: jest.fn(),
+        delete: jest.fn(),
+      },
+      roadmapNode: {
+        deleteMany: jest.fn(),
+      },
+      userNodeProgress: {
+        deleteMany: jest.fn(),
+      },
+      $transaction: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoadmapsService,
+        {
+          provide: PrismaService,
+          useValue: prismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RoadmapsService>(RoadmapsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getByIdForOwner', () => {
+    it('returns roadmap when owned by user', async () => {
+      const roadmapId = 'roadmap-1';
+      const userId = 'user-1';
+      const roadmap = {
+        id: roadmapId,
+        userId,
+        title: 'Backend roadmap',
+      };
+
+      prismaService.roadmap.findUnique.mockResolvedValue(roadmap);
+
+      await expect(service.getByIdForOwner(userId, roadmapId)).resolves.toEqual(roadmap);
+
+      expect(prismaService.roadmap.findUnique).toHaveBeenCalledWith({
+        where: { id: roadmapId },
+      });
+    });
+
+    it('throws 404 when roadmap does not belong to user', async () => {
+      prismaService.roadmap.findUnique.mockResolvedValue({
+        id: 'roadmap-1',
+        userId: 'other-user',
+      });
+
+      await expect(service.getByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+    });
+
+    it('throws 404 when roadmap not found', async () => {
+      prismaService.roadmap.findUnique.mockResolvedValue(null);
+
+      await expect(service.getByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+    });
+
+    it('throws 404 when roadmap is template (userId null)', async () => {
+      prismaService.roadmap.findUnique.mockResolvedValue({
+        id: 'roadmap-1',
+        userId: null,
+      });
+
+      await expect(service.getByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+    });
+  });
+
+  describe('deleteByIdForOwner', () => {
+    it('deletes roadmap', async () => {
+      const roadmapId = 'roadmap-1';
+      const userId = 'user-1';
+
+      prismaService.roadmap.findUnique.mockResolvedValue({ id: roadmapId, userId });
+      prismaService.roadmap.delete.mockResolvedValue({ id: roadmapId });
+
+      await service.deleteByIdForOwner(userId, roadmapId);
+
+      expect(prismaService.roadmap.delete).toHaveBeenCalledWith({
+        where: { id: roadmapId },
+      });
+      expect(prismaService.$transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws 404 and does not delete when roadmap belongs to another user', async () => {
+      prismaService.roadmap.findUnique.mockResolvedValue({ id: 'roadmap-1', userId: 'other-user' });
+
+      await expect(service.deleteByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+
+      expect(prismaService.$transaction).not.toHaveBeenCalled();
+      expect(prismaService.roadmap.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 and does not delete when roadmap not found', async () => {
+      prismaService.roadmap.findUnique.mockResolvedValue(null);
+
+      await expect(service.deleteByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+
+      expect(prismaService.$transaction).not.toHaveBeenCalled();
+      expect(prismaService.roadmap.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -7,6 +7,7 @@ import { NodeStatus, NodeType, RoleCategory } from '@repo/db/prisma/client';
 import {
   DeadlineInPastException,
   RoadmapGenerationUnavailableException,
+  RoadmapNotFoundException,
 } from '@/common/exceptions/app.exceptions';
 import { AiService } from '@/modules/ai/ai.service';
 import { PrismaService } from '@/modules/prisma/prisma.service';
@@ -46,6 +47,8 @@ interface RoadmapsPrismaMock {
   $transaction: AsyncMock<unknown, [unknown]>;
   roadmap: {
     count: AsyncMock<number>;
+    deleteMany: AsyncMock<{ count: number }>;
+    findFirst: AsyncMock<Record<string, unknown> | null>;
     findMany: AsyncMock<unknown[]>;
   };
   roadmapNode: {
@@ -77,6 +80,8 @@ const createPrismaMock = (txMock: TransactionMock): RoadmapsPrismaMock => ({
   }),
   roadmap: {
     count: jest.fn<Promise<number>, unknown[]>(),
+    deleteMany: jest.fn<Promise<{ count: number }>, unknown[]>(),
+    findFirst: jest.fn<Promise<Record<string, unknown> | null>, unknown[]>(),
     findMany: jest.fn<Promise<unknown[]>, unknown[]>(),
   },
   roadmapNode: { findMany: jest.fn<Promise<unknown[]>, unknown[]>() },
@@ -568,99 +573,84 @@ describe('RoadmapsService', () => {
       });
     });
   });
-});
-
-describe('RoadmapsService', () => {
-  let service: RoadmapsService;
-  let prismaService: {
-    roadmap: {
-      findUnique: jest.Mock;
-      delete: jest.Mock;
-    };
-    roadmapNode: {
-      deleteMany: jest.Mock;
-    };
-    userNodeProgress: {
-      deleteMany: jest.Mock;
-    };
-    $transaction: jest.Mock;
-  };
-
-  beforeEach(async () => {
-    prismaService = {
-      roadmap: {
-        findUnique: jest.fn(),
-        delete: jest.fn(),
-      },
-      roadmapNode: {
-        deleteMany: jest.fn(),
-      },
-      userNodeProgress: {
-        deleteMany: jest.fn(),
-      },
-      $transaction: jest.fn(),
-    };
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        RoadmapsService,
-        {
-          provide: PrismaService,
-          useValue: prismaService,
-        },
-      ],
-    }).compile();
-
-    service = module.get<RoadmapsService>(RoadmapsService);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
 
   describe('getByIdForOwner', () => {
-    it('returns roadmap when owned by user', async () => {
+    it('should return a formatted roadmap when owned by the user', async () => {
       const roadmapId = 'roadmap-1';
       const userId = 'user-1';
       const roadmap = {
+        deadlineDate: new Date('2025-10-01T00:00:00.000Z'),
+        description: 'A backend plan',
+        estimatedWeeks: null,
+        generatedAt: new Date('2025-04-24T07:00:00.000Z'),
+        goalName: 'Backend Intern at a product company',
+        hoursPerDay: createDecimal(2.5),
         id: roadmapId,
-        userId,
+        isTemplate: false,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
         title: 'Backend roadmap',
+        updatedAt: new Date('2025-04-25T08:00:00.000Z'),
+        userId,
       };
 
-      prismaService.roadmap.findUnique.mockResolvedValue(roadmap);
+      prisma.roadmap.findFirst.mockResolvedValue(roadmap);
 
-      await expect(service.getByIdForOwner(userId, roadmapId)).resolves.toEqual(roadmap);
+      await expect(service.getByIdForOwner(userId, roadmapId)).resolves.toEqual({
+        deadlineDate: '2025-10-01',
+        description: 'A backend plan',
+        estimatedWeeks: null,
+        generatedAt: '2025-04-24T07:00:00.000Z',
+        goalName: 'Backend Intern at a product company',
+        hoursPerDay: 2.5,
+        id: roadmapId,
+        isTemplate: false,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+        title: 'Backend roadmap',
+        updatedAt: '2025-04-25T08:00:00.000Z',
+        userId,
+      });
 
-      expect(prismaService.roadmap.findUnique).toHaveBeenCalledWith({
-        where: { id: roadmapId },
+      expect(prisma.roadmap.findFirst).toHaveBeenCalledWith({
+        select: {
+          deadlineDate: true,
+          description: true,
+          estimatedWeeks: true,
+          generatedAt: true,
+          goalName: true,
+          hoursPerDay: true,
+          id: true,
+          isTemplate: true,
+          roleCategory: true,
+          title: true,
+          updatedAt: true,
+          userId: true,
+        },
+        where: {
+          id: roadmapId,
+          isTemplate: false,
+          userId,
+        },
       });
     });
 
-    it('throws 404 when roadmap does not belong to user', async () => {
-      prismaService.roadmap.findUnique.mockResolvedValue({
-        id: 'roadmap-1',
-        userId: 'other-user',
-      });
+    it('should throw 404 when roadmap does not belong to user', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
 
       await expect(service.getByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
         RoadmapNotFoundException,
       );
     });
 
-    it('throws 404 when roadmap not found', async () => {
-      prismaService.roadmap.findUnique.mockResolvedValue(null);
+    it('should throw 404 when roadmap is not found', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
 
       await expect(service.getByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
         RoadmapNotFoundException,
       );
     });
 
-    it('throws 404 when roadmap is template (userId null)', async () => {
-      prismaService.roadmap.findUnique.mockResolvedValue({
-        id: 'roadmap-1',
-        userId: null,
-      });
+    it('should throw 404 when roadmap is a template', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
 
       await expect(service.getByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
         RoadmapNotFoundException,
@@ -669,41 +659,53 @@ describe('RoadmapsService', () => {
   });
 
   describe('deleteByIdForOwner', () => {
-    it('deletes roadmap', async () => {
+    it('should permanently delete an owned roadmap', async () => {
       const roadmapId = 'roadmap-1';
       const userId = 'user-1';
 
-      prismaService.roadmap.findUnique.mockResolvedValue({ id: roadmapId, userId });
-      prismaService.roadmap.delete.mockResolvedValue({ id: roadmapId });
+      prisma.roadmap.deleteMany.mockResolvedValue({ count: 1 });
 
       await service.deleteByIdForOwner(userId, roadmapId);
 
-      expect(prismaService.roadmap.delete).toHaveBeenCalledWith({
-        where: { id: roadmapId },
+      expect(prisma.roadmap.deleteMany).toHaveBeenCalledWith({
+        where: {
+          id: roadmapId,
+          isTemplate: false,
+          userId,
+        },
       });
-      expect(prismaService.$transaction).toHaveBeenCalledTimes(1);
     });
 
-    it('throws 404 and does not delete when roadmap belongs to another user', async () => {
-      prismaService.roadmap.findUnique.mockResolvedValue({ id: 'roadmap-1', userId: 'other-user' });
+    it('should throw 404 when roadmap belongs to another user', async () => {
+      prisma.roadmap.deleteMany.mockResolvedValue({ count: 0 });
 
       await expect(service.deleteByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
         RoadmapNotFoundException,
       );
 
-      expect(prismaService.$transaction).not.toHaveBeenCalled();
-      expect(prismaService.roadmap.delete).not.toHaveBeenCalled();
+      expect(prisma.roadmap.deleteMany).toHaveBeenCalledWith({
+        where: {
+          id: 'roadmap-1',
+          isTemplate: false,
+          userId: 'user-1',
+        },
+      });
     });
 
-    it('throws 404 and does not delete when roadmap not found', async () => {
-      prismaService.roadmap.findUnique.mockResolvedValue(null);
+    it('should throw 404 when roadmap is not found', async () => {
+      prisma.roadmap.deleteMany.mockResolvedValue({ count: 0 });
 
       await expect(service.deleteByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
         RoadmapNotFoundException,
       );
+    });
 
-      expect(prismaService.$transaction).not.toHaveBeenCalled();
-      expect(prismaService.roadmap.delete).not.toHaveBeenCalled();
+    it('should throw 404 when roadmap is a template', async () => {
+      prisma.roadmap.deleteMany.mockResolvedValue({ count: 0 });
+
+      await expect(service.deleteByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
     });
   });
 });


### PR DESCRIPTION
## Description
Implement GET /roadmaps/{roadmapId} and DELETE /roadmaps/{roadmapId} endpoints following API spec.

GET returns a single roadmap owned by the authenticated user
DELETE permanently removes a roadmap along with all related nodes and progress records

What does this PR do?

## Related Issue

Closes #38 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Add RoadmapsController with:

> GET /roadmaps/:id
> DELETE /roadmaps/:id

- Implement RoadmapsService:

> getByIdForOwner with ownership check and 404 handling
> deleteByIdForOwner with transactional cascade delete

- Ensure DELETE removes:

> user_node_progress
> roadmap_nodes
> roadmap

- Remove incorrect include: { nodes: true } to match API spec
- Add unit tests for service logic (success + 404 cases)

## How to Test

Steps to verify:

1. Login to obtain accessToken cookie
2. Call GET /roadmaps/{id}:

- Returns 200 with roadmap if owned
- Returns 404 if not found or not owned

3. Call DELETE /roadmaps/{id}:

- Returns 204 on success
- Roadmap and all related nodes/progress are removed from DB

4. Try accessing deleted roadmap → should return 404

## Screenshots (if FE)

N/A

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

- Ownership check intentionally returns 404 to avoid leaking resource existence
- Cascade delete is handled manually via transaction (no DB-level cascade assumed)
- GET endpoint returns only Roadmap fields (nodes handled via separate endpoint)
