### PR TITLE
Feature/39 roadmap nodes progress

### DIFF
--- a/apps/api/src/modules/roadmaps/dto/roadmap-nodes-filter.dto.ts
+++ b/apps/api/src/modules/roadmaps/dto/roadmap-nodes-filter.dto.ts
@@ -1,0 +1,21 @@
+import { NodeStatus, NodeType } from '@repo/db/prisma/client';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class RoadmapNodesFilterDto {
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.toUpperCase() : value))
+  @IsEnum(NodeType)
+  node_type?: NodeType;
+
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.toUpperCase() : value))
+  @IsEnum(NodeStatus)
+  status?: NodeStatus;
+
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @MaxLength(200)
+  q?: string;
+}

--- a/apps/api/src/modules/roadmaps/dto/roadmap-nodes-filter.dto.ts
+++ b/apps/api/src/modules/roadmaps/dto/roadmap-nodes-filter.dto.ts
@@ -2,19 +2,24 @@ import { NodeStatus, NodeType } from '@repo/db/prisma/client';
 import { Transform } from 'class-transformer';
 import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
 
+const toUppercaseString = ({ value }): unknown =>
+  typeof value === 'string' ? value.toUpperCase() : value;
+
+const toTrimmedString = ({ value }): unknown => (typeof value === 'string' ? value.trim() : value);
+
 export class RoadmapNodesFilterDto {
   @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.toUpperCase() : value))
+  @Transform(toUppercaseString)
   @IsEnum(NodeType)
   node_type?: NodeType;
 
   @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.toUpperCase() : value))
+  @Transform(toUppercaseString)
   @IsEnum(NodeStatus)
   status?: NodeStatus;
 
   @IsOptional()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @Transform(toTrimmedString)
   @IsString()
   @MaxLength(200)
   q?: string;

--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query } from '@nestjs/common';
 
 import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.decorator';
 import { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
+import { RoadmapNodesFilterDto } from './dto/roadmap-nodes-filter.dto';
 import { RoadmapsService } from './roadmaps.service';
 
 @Controller('roadmaps')
@@ -19,5 +20,15 @@ export class RoadmapsController {
   @HttpCode(HttpStatus.CREATED)
   async generate(@Body() dto: GenerateRoadmapDto, @CurrentUser() user: RequestUser) {
     return this.roadmapsService.generate(user.id, dto);
+  }
+
+  /**
+   * GET /roadmaps/nodes
+   *
+   * Returns a flat list of roadmap nodes with embedded progress for the user.
+   */
+  @Get('nodes')
+  async listNodes(@CurrentUser() user: RequestUser, @Query() query: RoadmapNodesFilterDto) {
+    return this.roadmapsService.listNodes(user.id, query);
   }
 }

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { NodeType, type Prisma } from '@repo/db/prisma/client';
 
 import {
   DeadlineInPastException,
@@ -7,7 +8,9 @@ import {
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
 import type { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
+import type { RoadmapNodesFilterDto } from './dto/roadmap-nodes-filter.dto';
 import type { AiNode, AiRoadmapOutput, FlatNode } from './types/ai-roadmap.types';
+import type { RoadmapNodesListResponse } from './types/roadmap-nodes.types';
 
 import { AiService } from '../ai/ai.service';
 import { DagreLayoutService } from './dagre-layout.service';
@@ -18,6 +21,11 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
 /** Timeline warning threshold: warn when total > available * (1 + THRESHOLD). */
 const FEASIBILITY_THRESHOLD = 0.15;
 
+const LEAF_NODE_TYPES: NodeType[] = [NodeType.REQUIRED, NodeType.OPTIONAL];
+
+const toNumberOrNull = (value: Prisma.Decimal | number | null) =>
+  value === null ? null : Number(value);
+
 @Injectable()
 export class RoadmapsService {
   private readonly logger = new Logger(RoadmapsService.name);
@@ -27,6 +35,100 @@ export class RoadmapsService {
     private readonly aiService: AiService,
     private readonly dagreLayout: DagreLayoutService,
   ) {}
+
+  async listNodes(userId: string, query: RoadmapNodesFilterDto): Promise<RoadmapNodesListResponse> {
+    const { node_type: nodeType, status, q } = query;
+    const trimmedQuery = q?.trim();
+
+    if (status && nodeType && !LEAF_NODE_TYPES.includes(nodeType)) {
+      return { nodes: [] };
+    }
+
+    const where: Prisma.RoadmapNodeWhereInput = {
+      roadmap: { userId },
+    };
+
+    if (nodeType) {
+      where.nodeType = nodeType;
+    }
+
+    if (status) {
+      where.userNodeProgress = {
+        some: {
+          userId,
+          status,
+        },
+      };
+
+      if (!nodeType) {
+        where.nodeType = { in: LEAF_NODE_TYPES };
+      }
+    }
+
+    if (trimmedQuery) {
+      where.name = { contains: trimmedQuery, mode: 'insensitive' };
+    }
+
+    const nodes = await this.prisma.roadmapNode.findMany({
+      where,
+      select: {
+        id: true,
+        roadmapId: true,
+        parentId: true,
+        skillId: true,
+        name: true,
+        description: true,
+        nodeType: true,
+        estimatedHours: true,
+        posX: true,
+        posY: true,
+        userNodeProgress: {
+          where: { userId },
+          select: {
+            id: true,
+            userId: true,
+            roadmapNodeId: true,
+            status: true,
+            startedAt: true,
+            completedAt: true,
+            quizScorePct: true,
+            quizPassed: true,
+          },
+        },
+      },
+    });
+
+    return {
+      nodes: nodes.map((node) => {
+        const progress = node.userNodeProgress[0] ?? null;
+
+        return {
+          id: node.id,
+          roadmap_id: node.roadmapId,
+          parent_id: node.parentId,
+          skill_id: node.skillId,
+          name: node.name,
+          description: node.description,
+          node_type: node.nodeType,
+          estimated_hours: toNumberOrNull(node.estimatedHours),
+          pos_x: Number(node.posX),
+          pos_y: Number(node.posY),
+          progress: progress
+            ? {
+                id: progress.id,
+                user_id: progress.userId,
+                roadmap_node_id: progress.roadmapNodeId,
+                status: progress.status,
+                started_at: progress.startedAt,
+                completed_at: progress.completedAt,
+                quiz_score_pct: toNumberOrNull(progress.quizScorePct),
+                quiz_passed: progress.quizPassed,
+              }
+            : null,
+        };
+      }),
+    };
+  }
 
   /**
    * Orchestrates roadmap generation end-to-end:

--- a/apps/api/src/modules/roadmaps/types/roadmap-nodes.types.ts
+++ b/apps/api/src/modules/roadmaps/types/roadmap-nodes.types.ts
@@ -1,0 +1,30 @@
+import type { NodeStatus, NodeType } from '@repo/db/prisma/client';
+
+export interface UserNodeProgressResponse {
+  id: string;
+  user_id: string;
+  roadmap_node_id: string;
+  status: NodeStatus;
+  started_at: Date | null;
+  completed_at: Date | null;
+  quiz_score_pct: number | null;
+  quiz_passed: boolean | null;
+}
+
+export interface RoadmapNodeWithUserProgressResponse {
+  id: string;
+  roadmap_id: string;
+  parent_id: string | null;
+  skill_id: string | null;
+  name: string;
+  description: string | null;
+  node_type: NodeType;
+  estimated_hours: number | null;
+  pos_x: number;
+  pos_y: number;
+  progress: UserNodeProgressResponse | null;
+}
+
+export interface RoadmapNodesListResponse {
+  nodes: RoadmapNodeWithUserProgressResponse[];
+}

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -1,0 +1,51 @@
+import type { TestingModule } from '@nestjs/testing';
+
+import { Test } from '@nestjs/testing';
+
+import { RoadmapsController } from '@/modules/roadmaps/roadmaps.controller';
+import { RoadmapsService } from '@/modules/roadmaps/roadmaps.service';
+
+describe('RoadmapsController', () => {
+  let controller: RoadmapsController;
+
+  const mockRoadmapsService = {
+    generate: jest.fn(),
+    listNodes: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RoadmapsController],
+      providers: [
+        {
+          provide: RoadmapsService,
+          useValue: mockRoadmapsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<RoadmapsController>(RoadmapsController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call listNodes and return response', async () => {
+    const mockUser = {
+      id: 'user-1',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      role: 'USER',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    const mockResponse = { nodes: [] };
+
+    mockRoadmapsService.listNodes.mockResolvedValue(mockResponse);
+
+    const result = await controller.listNodes(mockUser, { q: 'REST' });
+
+    expect(mockRoadmapsService.listNodes).toHaveBeenCalledWith('user-1', { q: 'REST' });
+    expect(result).toEqual(mockResponse);
+  });
+});

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -2,6 +2,7 @@
 import type { TestingModule } from '@nestjs/testing';
 
 import { Test } from '@nestjs/testing';
+import { NodeStatus, NodeType } from '@repo/db/prisma/client';
 
 import {
   DeadlineInPastException,
@@ -53,6 +54,7 @@ describe('RoadmapsService', () => {
             skillPrerequisite: {
               findMany: jest.fn().mockResolvedValue(MOCK_PRISMA_SKILL_PREREQUISITES),
             },
+            roadmapNode: { findMany: jest.fn() },
             $transaction: jest
               .fn()
               .mockImplementation(async (fn: (tx: typeof txMock) => unknown) => await fn(txMock)),
@@ -262,6 +264,143 @@ describe('RoadmapsService', () => {
       const txCallString = JSON.stringify(txCalls);
       // quizAnswers answers are free text strings 'A1'…'A7'
       expect(txCallString).not.toContain('quizAnswers');
+    });
+  });
+
+  describe('listNodes', () => {
+    it('should return nodes with embedded progress', async () => {
+      const mockNodes = [
+        {
+          id: 'node-1',
+          roadmapId: 'roadmap-1',
+          parentId: null,
+          skillId: null,
+          name: 'Backend Foundations',
+          description: null,
+          nodeType: NodeType.GROUP,
+          estimatedHours: null,
+          posX: 120,
+          posY: 200,
+          userNodeProgress: [],
+        },
+        {
+          id: 'node-2',
+          roadmapId: 'roadmap-1',
+          parentId: 'node-1',
+          skillId: 'skill-1',
+          name: 'REST API',
+          description: null,
+          nodeType: NodeType.REQUIRED,
+          estimatedHours: 6,
+          posX: 140,
+          posY: 240,
+          userNodeProgress: [
+            {
+              id: 'progress-1',
+              userId: MOCK_USER_ID,
+              roadmapNodeId: 'node-2',
+              status: NodeStatus.COMPLETED,
+              startedAt: new Date('2026-01-01T00:00:00Z'),
+              completedAt: new Date('2026-01-02T00:00:00Z'),
+              quizScorePct: 80,
+              quizPassed: true,
+            },
+          ],
+        },
+      ];
+
+      prisma.roadmapNode.findMany.mockResolvedValue(mockNodes);
+
+      const result = await service.listNodes(MOCK_USER_ID, {});
+
+      expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { roadmap: { userId: MOCK_USER_ID } },
+        }),
+      );
+      expect(result).toEqual({
+        nodes: [
+          {
+            id: 'node-1',
+            roadmap_id: 'roadmap-1',
+            parent_id: null,
+            skill_id: null,
+            name: 'Backend Foundations',
+            description: null,
+            node_type: NodeType.GROUP,
+            estimated_hours: null,
+            pos_x: 120,
+            pos_y: 200,
+            progress: null,
+          },
+          {
+            id: 'node-2',
+            roadmap_id: 'roadmap-1',
+            parent_id: 'node-1',
+            skill_id: 'skill-1',
+            name: 'REST API',
+            description: null,
+            node_type: NodeType.REQUIRED,
+            estimated_hours: 6,
+            pos_x: 140,
+            pos_y: 240,
+            progress: {
+              id: 'progress-1',
+              user_id: MOCK_USER_ID,
+              roadmap_node_id: 'node-2',
+              status: NodeStatus.COMPLETED,
+              started_at: new Date('2026-01-01T00:00:00Z'),
+              completed_at: new Date('2026-01-02T00:00:00Z'),
+              quiz_score_pct: 80,
+              quiz_passed: true,
+            },
+          },
+        ],
+      });
+    });
+
+    it('should filter by status on leaf nodes', async () => {
+      prisma.roadmapNode.findMany.mockResolvedValue([]);
+
+      await service.listNodes(MOCK_USER_ID, { status: NodeStatus.COMPLETED });
+
+      expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            nodeType: { in: [NodeType.REQUIRED, NodeType.OPTIONAL] },
+            userNodeProgress: {
+              some: {
+                status: NodeStatus.COMPLETED,
+                userId: MOCK_USER_ID,
+              },
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should apply case-insensitive name filtering', async () => {
+      prisma.roadmapNode.findMany.mockResolvedValue([]);
+
+      await service.listNodes(MOCK_USER_ID, { q: 'REST' });
+
+      expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            name: { contains: 'REST', mode: 'insensitive' },
+          }),
+        }),
+      );
+    });
+
+    it('should return empty when status is set for non-leaf node_type', async () => {
+      const result = await service.listNodes(MOCK_USER_ID, {
+        node_type: NodeType.GROUP,
+        status: NodeStatus.COMPLETED,
+      });
+
+      expect(result).toEqual({ nodes: [] });
+      expect(prisma.roadmapNode.findMany).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds a roadmap nodes listing endpoint with progress embedding and filters, updates response type naming, and adds unit tests with a Dagre mock for Jest.

## Related Issue

Closes #39 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Add `GET /roadmaps/nodes` with `node_type`, `status`, `q` filters and embedded progress
- Introduce/rename response types for clearer intent
- Add unit tests and mock `@dagrejs/dagre` for Jest

## How to Test

Steps to verify:

1. `pnpm --filter api test -- roadmaps.controller.spec.ts roadmaps.service.spec.ts`
2. (Optional) call `GET /api/v1/roadmaps/nodes?status=IN_PROGRESS`

## Screenshots (if FE)

N/A

## Checklist

- [ ] Code compiles and runs
- [ ] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes