### PR TITLE
Improvement/63 roadmapid path filter

### DIFF
--- a/apps/api/src/modules/roadmaps/dto/roadmap-nodes-filter.dto.ts
+++ b/apps/api/src/modules/roadmaps/dto/roadmap-nodes-filter.dto.ts
@@ -11,7 +11,7 @@ export class RoadmapNodesFilterDto {
   @IsOptional()
   @Transform(toUppercaseString)
   @IsEnum(NodeType)
-  node_type?: NodeType;
+  nodeType?: NodeType;
 
   @IsOptional()
   @Transform(toUppercaseString)

--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query } from '@nestjs/common';
 
 import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.decorator';
 import { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
@@ -23,12 +23,16 @@ export class RoadmapsController {
   }
 
   /**
-   * GET /roadmaps/nodes
+   * GET /roadmaps/:roadmapId/nodes
    *
    * Returns a flat list of roadmap nodes with embedded progress for the user.
    */
-  @Get('nodes')
-  async listNodes(@CurrentUser() user: RequestUser, @Query() query: RoadmapNodesFilterDto) {
-    return this.roadmapsService.listNodes(user.id, query);
+  @Get(':roadmapId/nodes')
+  async listNodes(
+    @CurrentUser() user: RequestUser,
+    @Param('roadmapId') roadmapId: string,
+    @Query() query: RoadmapNodesFilterDto,
+  ) {
+    return this.roadmapsService.listNodes(user.id, roadmapId, query);
   }
 }

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -36,7 +36,11 @@ export class RoadmapsService {
     private readonly dagreLayout: DagreLayoutService,
   ) {}
 
-  async listNodes(userId: string, query: RoadmapNodesFilterDto): Promise<RoadmapNodesListResponse> {
+  async listNodes(
+    userId: string,
+    roadmapId: string,
+    query: RoadmapNodesFilterDto,
+  ): Promise<RoadmapNodesListResponse> {
     const { node_type: nodeType, status, q } = query;
     const trimmedQuery = q?.trim();
 
@@ -45,6 +49,7 @@ export class RoadmapsService {
     }
 
     const where: Prisma.RoadmapNodeWhereInput = {
+      roadmapId,
       roadmap: { userId },
     };
 
@@ -86,7 +91,6 @@ export class RoadmapsService {
           where: { userId },
           select: {
             id: true,
-            userId: true,
             roadmapNodeId: true,
             status: true,
             startedAt: true,
@@ -116,7 +120,6 @@ export class RoadmapsService {
           progress: progress
             ? {
                 id: progress.id,
-                user_id: progress.userId,
                 roadmap_node_id: progress.roadmapNodeId,
                 status: progress.status,
                 started_at: progress.startedAt,

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -41,7 +41,7 @@ export class RoadmapsService {
     roadmapId: string,
     query: RoadmapNodesFilterDto,
   ): Promise<RoadmapNodesListResponse> {
-    const { node_type: nodeType, status, q } = query;
+    const { nodeType, status, q } = query;
     const trimmedQuery = q?.trim();
 
     if (status && nodeType && !LEAF_NODE_TYPES.includes(nodeType)) {
@@ -108,24 +108,24 @@ export class RoadmapsService {
 
         return {
           id: node.id,
-          roadmap_id: node.roadmapId,
-          parent_id: node.parentId,
-          skill_id: node.skillId,
+          roadmapId: node.roadmapId,
+          parentId: node.parentId,
+          skillId: node.skillId,
           name: node.name,
           description: node.description,
-          node_type: node.nodeType,
-          estimated_hours: toNumberOrNull(node.estimatedHours),
-          pos_x: Number(node.posX),
-          pos_y: Number(node.posY),
+          nodeType: node.nodeType,
+          estimatedHours: toNumberOrNull(node.estimatedHours),
+          posX: Number(node.posX),
+          posY: Number(node.posY),
           progress: progress
             ? {
                 id: progress.id,
-                roadmap_node_id: progress.roadmapNodeId,
+                roadmapNodeId: progress.roadmapNodeId,
                 status: progress.status,
-                started_at: progress.startedAt,
-                completed_at: progress.completedAt,
-                quiz_score_pct: toNumberOrNull(progress.quizScorePct),
-                quiz_passed: progress.quizPassed,
+                startedAt: progress.startedAt,
+                completedAt: progress.completedAt,
+                quizScorePct: toNumberOrNull(progress.quizScorePct),
+                quizPassed: progress.quizPassed,
               }
             : null,
         };

--- a/apps/api/src/modules/roadmaps/types/roadmap-nodes.types.ts
+++ b/apps/api/src/modules/roadmaps/types/roadmap-nodes.types.ts
@@ -2,7 +2,6 @@ import type { NodeStatus, NodeType } from '@repo/db/prisma/client';
 
 export interface UserNodeProgressResponse {
   id: string;
-  user_id: string;
   roadmap_node_id: string;
   status: NodeStatus;
   started_at: Date | null;

--- a/apps/api/src/modules/roadmaps/types/roadmap-nodes.types.ts
+++ b/apps/api/src/modules/roadmaps/types/roadmap-nodes.types.ts
@@ -2,25 +2,25 @@ import type { NodeStatus, NodeType } from '@repo/db/prisma/client';
 
 export interface UserNodeProgressResponse {
   id: string;
-  roadmap_node_id: string;
+  roadmapNodeId: string;
   status: NodeStatus;
-  started_at: Date | null;
-  completed_at: Date | null;
-  quiz_score_pct: number | null;
-  quiz_passed: boolean | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  quizScorePct: number | null;
+  quizPassed: boolean | null;
 }
 
 export interface RoadmapNodeWithUserProgressResponse {
   id: string;
-  roadmap_id: string;
-  parent_id: string | null;
-  skill_id: string | null;
+  roadmapId: string;
+  parentId: string | null;
+  skillId: string | null;
   name: string;
   description: string | null;
-  node_type: NodeType;
-  estimated_hours: number | null;
-  pos_x: number;
-  pos_y: number;
+  nodeType: NodeType;
+  estimatedHours: number | null;
+  posX: number;
+  posY: number;
   progress: UserNodeProgressResponse | null;
 }
 

--- a/apps/api/test/unit/onboarding/onboarding.service.spec.ts
+++ b/apps/api/test/unit/onboarding/onboarding.service.spec.ts
@@ -1,10 +1,18 @@
 import type { TestingModule } from '@nestjs/testing';
 
 import { Test } from '@nestjs/testing';
+import { RoleCategory } from '@repo/db/prisma/client';
 
 import { ExternalServiceErrorException } from '@/common/exceptions/app.exceptions';
 import { AiService } from '@/modules/ai/ai.service';
 import { OnboardingService } from '@/modules/onboarding/onboarding.service';
+
+const toRoleSlug = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
 
 describe('OnboardingService', () => {
   let service: OnboardingService;
@@ -71,6 +79,13 @@ describe('OnboardingService', () => {
         questions: [{ question: 'Goal?', possibleAnswers: ['Career', 'Project'] }],
       };
 
+      const allowedRoleSlugs = Object.values(RoleCategory).map(toRoleSlug);
+      const normalizedRole = toRoleSlug(quizResponse.roleCategory);
+      const fallbackRole = allowedRoleSlugs[0] ?? 'backend';
+      const expectedRole = allowedRoleSlugs.includes(normalizedRole)
+        ? normalizedRole
+        : fallbackRole;
+
       jest
         .spyOn(aiService, 'generateOnboardingQuiz')
         .mockResolvedValue(JSON.stringify(quizResponse));
@@ -79,7 +94,7 @@ describe('OnboardingService', () => {
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(aiService.generateOnboardingQuiz).toHaveBeenCalled();
-      expect(result).toEqual(quizResponse);
+      expect(result).toEqual({ ...quizResponse, roleCategory: expectedRole });
     });
 
     it('should throw ExternalServiceErrorException when JSON parse fails', async () => {

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -43,9 +43,11 @@ describe('RoadmapsController', () => {
 
     mockRoadmapsService.listNodes.mockResolvedValue(mockResponse);
 
-    const result = await controller.listNodes(mockUser, { q: 'REST' });
+    const result = await controller.listNodes(mockUser, 'roadmap-1', { q: 'REST' });
 
-    expect(mockRoadmapsService.listNodes).toHaveBeenCalledWith('user-1', { q: 'REST' });
+    expect(mockRoadmapsService.listNodes).toHaveBeenCalledWith('user-1', 'roadmap-1', {
+      q: 'REST',
+    });
     expect(result).toEqual(mockResponse);
   });
 });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -268,6 +268,8 @@ describe('RoadmapsService', () => {
   });
 
   describe('listNodes', () => {
+    const roadmapId = 'roadmap-1';
+
     it('should return nodes with embedded progress', async () => {
       const mockNodes = [
         {
@@ -311,11 +313,11 @@ describe('RoadmapsService', () => {
 
       prisma.roadmapNode.findMany.mockResolvedValue(mockNodes);
 
-      const result = await service.listNodes(MOCK_USER_ID, {});
+      const result = await service.listNodes(MOCK_USER_ID, roadmapId, {});
 
       expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { roadmap: { userId: MOCK_USER_ID } },
+          where: { roadmapId, roadmap: { userId: MOCK_USER_ID } },
         }),
       );
       expect(result).toEqual({
@@ -346,7 +348,6 @@ describe('RoadmapsService', () => {
             pos_y: 240,
             progress: {
               id: 'progress-1',
-              user_id: MOCK_USER_ID,
               roadmap_node_id: 'node-2',
               status: NodeStatus.COMPLETED,
               started_at: new Date('2026-01-01T00:00:00Z'),
@@ -362,11 +363,12 @@ describe('RoadmapsService', () => {
     it('should filter by status on leaf nodes', async () => {
       prisma.roadmapNode.findMany.mockResolvedValue([]);
 
-      await service.listNodes(MOCK_USER_ID, { status: NodeStatus.COMPLETED });
+      await service.listNodes(MOCK_USER_ID, roadmapId, { status: NodeStatus.COMPLETED });
 
       expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
+            roadmapId,
             nodeType: { in: [NodeType.REQUIRED, NodeType.OPTIONAL] },
             userNodeProgress: {
               some: {
@@ -382,11 +384,12 @@ describe('RoadmapsService', () => {
     it('should apply case-insensitive name filtering', async () => {
       prisma.roadmapNode.findMany.mockResolvedValue([]);
 
-      await service.listNodes(MOCK_USER_ID, { q: 'REST' });
+      await service.listNodes(MOCK_USER_ID, roadmapId, { q: 'REST' });
 
       expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
+            roadmapId,
             name: { contains: 'REST', mode: 'insensitive' },
           }),
         }),
@@ -394,7 +397,7 @@ describe('RoadmapsService', () => {
     });
 
     it('should return empty when status is set for non-leaf node_type', async () => {
-      const result = await service.listNodes(MOCK_USER_ID, {
+      const result = await service.listNodes(MOCK_USER_ID, roadmapId, {
         node_type: NodeType.GROUP,
         status: NodeStatus.COMPLETED,
       });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -324,36 +324,36 @@ describe('RoadmapsService', () => {
         nodes: [
           {
             id: 'node-1',
-            roadmap_id: 'roadmap-1',
-            parent_id: null,
-            skill_id: null,
+            roadmapId: 'roadmap-1',
+            parentId: null,
+            skillId: null,
             name: 'Backend Foundations',
             description: null,
-            node_type: NodeType.GROUP,
-            estimated_hours: null,
-            pos_x: 120,
-            pos_y: 200,
+            nodeType: NodeType.GROUP,
+            estimatedHours: null,
+            posX: 120,
+            posY: 200,
             progress: null,
           },
           {
             id: 'node-2',
-            roadmap_id: 'roadmap-1',
-            parent_id: 'node-1',
-            skill_id: 'skill-1',
+            roadmapId: 'roadmap-1',
+            parentId: 'node-1',
+            skillId: 'skill-1',
             name: 'REST API',
             description: null,
-            node_type: NodeType.REQUIRED,
-            estimated_hours: 6,
-            pos_x: 140,
-            pos_y: 240,
+            nodeType: NodeType.REQUIRED,
+            estimatedHours: 6,
+            posX: 140,
+            posY: 240,
             progress: {
               id: 'progress-1',
-              roadmap_node_id: 'node-2',
+              roadmapNodeId: 'node-2',
               status: NodeStatus.COMPLETED,
-              started_at: new Date('2026-01-01T00:00:00Z'),
-              completed_at: new Date('2026-01-02T00:00:00Z'),
-              quiz_score_pct: 80,
-              quiz_passed: true,
+              startedAt: new Date('2026-01-01T00:00:00Z'),
+              completedAt: new Date('2026-01-02T00:00:00Z'),
+              quizScorePct: 80,
+              quizPassed: true,
             },
           },
         ],
@@ -396,9 +396,9 @@ describe('RoadmapsService', () => {
       );
     });
 
-    it('should return empty when status is set for non-leaf node_type', async () => {
+    it('should return empty when status is set for non-leaf nodeType', async () => {
       const result = await service.listNodes(MOCK_USER_ID, roadmapId, {
-        node_type: NodeType.GROUP,
+        nodeType: NodeType.GROUP,
         status: NodeStatus.COMPLETED,
       });
 


### PR DESCRIPTION
## Description

Update the roadmap nodes API to filter by `roadmapId` in the path, keep existing filters, and remove `user_id` from the progress response.

## Related Issue

Closes #63 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Switch route to GET /roadmaps/:roadmapId/nodes and filter by roadmapId + userId
- Update unit tests for roadmaps controller/service
- Remove user_id from progress response

## How to Test

Steps to verify:

1. pnpm --filter api test
2. Call GET /roadmaps/:roadmapId/nodes (with a valid token) and verify it returns only nodes for that roadmap
3. Try node_type/status/q filters and confirm they still work

## Screenshots (if FE)

N/A

## Checklist

- [ ] Code compiles and runs
- [ ] No console errors
- [ ] Follows project conventions
- [ ] Self-reviewed

## Notes

No additional notes.