### PR TITLE
Feature/43 fetch node quiz questions

### DIFF
--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -70,4 +70,18 @@ export class RoadmapsController {
   async remove(@CurrentUser() user: RequestUser, @Param('roadmapId') roadmapId: string) {
     await this.roadmapsService.deleteByIdForOwner(user.id, roadmapId);
   }
+
+  /**
+   * GET /roadmaps/:roadmapId/nodes/:nodeId/quiz
+   *
+   * Returns exactly 5 public quiz questions for a required/optional leaf node's skill.
+   */
+  @Get(':roadmapId/nodes/:nodeId/quiz')
+  async getNodeQuiz(
+    @CurrentUser() user: RequestUser,
+    @Param('roadmapId') roadmapId: string,
+    @Param('nodeId') nodeId: string,
+  ) {
+    return this.roadmapsService.getNodeQuiz(user.id, roadmapId, nodeId);
+  }
 }

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, UnprocessableEntityException } from '@nestjs/common';
 import { NodeType, type Prisma, type Roadmap } from '@repo/db/prisma/client';
 
 import {
+  AppNotFoundException,
   DeadlineInPastException,
   RoadmapGenerationUnavailableException,
   RoadmapNotFoundException,
@@ -13,6 +14,7 @@ import type { ListRoadmapsQueryDto } from './dto/list-roadmaps-query.dto';
 import type { RoadmapNodesFilterDto } from './dto/roadmap-nodes-filter.dto';
 import type { PaginatedRoadmapsResponseDto, RoadmapResponseDto } from './dto/roadmap-response.dto';
 import type { AiNode, AiRoadmapOutput, FlatNode } from './types/ai-roadmap.types';
+import type { RoadmapNodeQuizResponse } from './types/roadmap-node-quiz.types';
 import type { RoadmapNodesListResponse } from './types/roadmap-nodes.types';
 
 import { AiService } from '../ai/ai.service';
@@ -189,6 +191,56 @@ export class RoadmapsService {
             : null,
         };
       }),
+    };
+  }
+
+  async getNodeQuiz(
+    userId: string,
+    roadmapId: string,
+    nodeId: string,
+  ): Promise<RoadmapNodeQuizResponse> {
+    const node = await this.prisma.roadmapNode.findFirst({
+      where: {
+        id: nodeId,
+        roadmapId,
+        roadmap: { userId },
+      },
+      select: {
+        id: true,
+        nodeType: true,
+        skillId: true,
+      },
+    });
+
+    if (!node) {
+      throw new AppNotFoundException('Roadmap node not found');
+    }
+
+    if (!LEAF_NODE_TYPES.includes(node.nodeType) || !node.skillId) {
+      throw new UnprocessableEntityException({
+        code: 42200,
+        message: 'Quiz is only available for required or optional leaf nodes',
+      });
+    }
+
+    const questions = await this.prisma.quizQuestion.findMany({
+      where: { skillId: node.skillId },
+      select: {
+        id: true,
+        questionText: true,
+        optionA: true,
+        optionB: true,
+        optionC: true,
+        optionD: true,
+      },
+      orderBy: { createdAt: 'asc' },
+      take: 5,
+    });
+
+    return {
+      nodeId: node.id,
+      skillId: node.skillId,
+      questions,
     };
   }
 

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -4,6 +4,7 @@ import { NodeType, type Prisma, type Roadmap } from '@repo/db/prisma/client';
 import {
   AppNotFoundException,
   DeadlineInPastException,
+  InternalServerErrorException,
   RoadmapGenerationUnavailableException,
   RoadmapNotFoundException,
 } from '@/common/exceptions/app.exceptions';
@@ -27,6 +28,7 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const FEASIBILITY_THRESHOLD = 0.15;
 
 const LEAF_NODE_TYPES: NodeType[] = [NodeType.REQUIRED, NodeType.OPTIONAL];
+const NODE_QUIZ_QUESTION_COUNT = 5;
 
 const ROADMAP_SELECT = {
   deadlineDate: true,
@@ -233,14 +235,29 @@ export class RoadmapsService {
         optionC: true,
         optionD: true,
       },
-      orderBy: { createdAt: 'asc' },
-      take: 5,
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: NODE_QUIZ_QUESTION_COUNT,
     });
+
+    if (questions.length !== NODE_QUIZ_QUESTION_COUNT) {
+      this.logger.error(
+        `Expected ${NODE_QUIZ_QUESTION_COUNT} quiz questions for skill ` +
+          `${node.skillId}, got ${questions.length}`,
+      );
+      throw new InternalServerErrorException('Quiz question catalog is incomplete for this skill');
+    }
 
     return {
       nodeId: node.id,
       skillId: node.skillId,
-      questions,
+      questions: questions.map((question) => ({
+        id: question.id,
+        questionText: question.questionText,
+        optionA: question.optionA,
+        optionB: question.optionB,
+        optionC: question.optionC,
+        optionD: question.optionD,
+      })),
     };
   }
 

--- a/apps/api/src/modules/roadmaps/types/roadmap-node-quiz.types.ts
+++ b/apps/api/src/modules/roadmaps/types/roadmap-node-quiz.types.ts
@@ -1,0 +1,14 @@
+export interface QuizQuestionPublic {
+  id: string;
+  questionText: string;
+  optionA: string;
+  optionB: string;
+  optionC: string;
+  optionD: string;
+}
+
+export interface RoadmapNodeQuizResponse {
+  nodeId: string;
+  skillId: string;
+  questions: QuizQuestionPublic[];
+}

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -11,7 +11,6 @@ describe('RoadmapsController', () => {
   const mockRoadmapsService = {
     deleteByIdForOwner: jest.fn(),
     generate: jest.fn(),
-    getByIdForOwner: jest.fn(),
     listNodes: jest.fn(),
     listUserRoadmaps: jest.fn(),
   };
@@ -134,5 +133,27 @@ describe('RoadmapsController', () => {
       expect(mockRoadmapsService.deleteByIdForOwner).toHaveBeenCalledWith('user-1', 'roadmap-1');
       expect(result).toBeUndefined();
     });
+  });
+
+  it('should call getNodeQuiz and return response', async () => {
+    const mockUser = {
+      id: 'user-1',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      role: 'USER',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    const mockResponse = {
+      nodeId: 'node-1',
+      skillId: 'skill-1',
+      questions: [],
+    };
+
+    mockRoadmapsService.getNodeQuiz.mockResolvedValue(mockResponse);
+
+    const result = await controller.getNodeQuiz(mockUser, 'roadmap-1', 'node-1');
+
+    expect(mockRoadmapsService.getNodeQuiz).toHaveBeenCalledWith('user-1', 'roadmap-1', 'node-1');
+    expect(result).toEqual(mockResponse);
   });
 });

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -11,6 +11,8 @@ describe('RoadmapsController', () => {
   const mockRoadmapsService = {
     deleteByIdForOwner: jest.fn(),
     generate: jest.fn(),
+    getByIdForOwner: jest.fn(),
+    getNodeQuiz: jest.fn(),
     listNodes: jest.fn(),
     listUserRoadmaps: jest.fn(),
   };

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/unbound-method */
 import type { TestingModule } from '@nestjs/testing';
 
 import { Test } from '@nestjs/testing';
@@ -7,6 +7,7 @@ import { NodeStatus, NodeType, RoleCategory } from '@repo/db/prisma/client';
 import {
   AppNotFoundException,
   DeadlineInPastException,
+  InternalServerErrorException,
   RoadmapGenerationUnavailableException,
   RoadmapNotFoundException,
 } from '@/common/exceptions/app.exceptions';
@@ -44,8 +45,26 @@ type AsyncMock<TResult = unknown, TArgs extends unknown[] = unknown[]> = jest.Mo
   TArgs
 >;
 
+interface RoadmapNodeQuizSelection {
+  id: string;
+  nodeType: NodeType;
+  skillId: string | null;
+}
+
+interface QuizQuestionPublicRecord {
+  id: string;
+  questionText: string;
+  optionA: string;
+  optionB: string;
+  optionC: string;
+  optionD: string;
+}
+
 interface RoadmapsPrismaMock {
   $transaction: AsyncMock<unknown, [unknown]>;
+  quizQuestion: {
+    findMany: AsyncMock<QuizQuestionPublicRecord[]>;
+  };
   roadmap: {
     count: AsyncMock<number>;
     deleteMany: AsyncMock<{ count: number }>;
@@ -53,6 +72,7 @@ interface RoadmapsPrismaMock {
     findMany: AsyncMock<unknown[]>;
   };
   roadmapNode: {
+    findFirst: AsyncMock<RoadmapNodeQuizSelection | null>;
     findMany: AsyncMock<unknown[]>;
   };
   skill: {
@@ -79,13 +99,19 @@ const createPrismaMock = (txMock: TransactionMock): RoadmapsPrismaMock => ({
     const transactionCallback = input as TransactionCallback;
     return transactionCallback(txMock);
   }),
+  quizQuestion: {
+    findMany: jest.fn<Promise<QuizQuestionPublicRecord[]>, unknown[]>(),
+  },
   roadmap: {
     count: jest.fn<Promise<number>, unknown[]>(),
     deleteMany: jest.fn<Promise<{ count: number }>, unknown[]>(),
     findFirst: jest.fn<Promise<Record<string, unknown> | null>, unknown[]>(),
     findMany: jest.fn<Promise<unknown[]>, unknown[]>(),
   },
-  roadmapNode: { findMany: jest.fn<Promise<unknown[]>, unknown[]>() },
+  roadmapNode: {
+    findFirst: jest.fn<Promise<RoadmapNodeQuizSelection | null>, unknown[]>(),
+    findMany: jest.fn<Promise<unknown[]>, unknown[]>(),
+  },
   skill: {
     findMany: jest.fn<Promise<typeof MOCK_SKILLS>, unknown[]>().mockResolvedValue(MOCK_SKILLS),
   },
@@ -111,16 +137,7 @@ describe('RoadmapsService', () => {
         RoadmapsService,
         {
           provide: PrismaService,
-          useValue: {
-            skill: { findMany: jest.fn().mockResolvedValue(MOCK_SKILLS) },
-            skillPrerequisite: {
-              findMany: jest.fn().mockResolvedValue(MOCK_PRISMA_SKILL_PREREQUISITES),
-            },
-            roadmapNode: { findMany: jest.fn() },
-            $transaction: jest
-              .fn()
-              .mockImplementation(async (fn: (tx: typeof txMock) => unknown) => await fn(txMock)),
-          },
+          useValue: prismaMock,
         },
         {
           provide: AiService,
@@ -730,6 +747,7 @@ describe('RoadmapsService', () => {
       optionB: 'POST',
       optionC: 'PUT',
       optionD: 'PATCH',
+      correctOption: 'C',
     }));
 
     it('should return exactly 5 public quiz questions for a leaf node', async () => {
@@ -764,15 +782,36 @@ describe('RoadmapsService', () => {
           optionC: true,
           optionD: true,
         },
-        orderBy: { createdAt: 'asc' },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
         take: 5,
       });
       expect(JSON.stringify(result)).not.toContain('correctOption');
       expect(result).toEqual({
         nodeId,
         skillId,
-        questions: mockQuestions,
+        questions: mockQuestions.map((question) => ({
+          id: question.id,
+          questionText: question.questionText,
+          optionA: question.optionA,
+          optionB: question.optionB,
+          optionC: question.optionC,
+          optionD: question.optionD,
+        })),
       });
+    });
+
+    it('should allow optional leaf nodes', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.OPTIONAL,
+        skillId,
+      });
+      prisma.quizQuestion.findMany.mockResolvedValue(mockQuestions);
+
+      const result = await service.getNodeQuiz(MOCK_USER_ID, roadmapId, nodeId);
+
+      expect(result.questions).toHaveLength(5);
+      expect(result.questions[0]?.id).toBe('question-1');
     });
 
     it('should throw 404 when node is not found in the roadmap', async () => {
@@ -784,7 +823,7 @@ describe('RoadmapsService', () => {
       expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
     });
 
-    it('should throw 422 for group or milestone nodes', async () => {
+    it('should throw 422 for group nodes', async () => {
       prisma.roadmapNode.findFirst.mockResolvedValue({
         id: nodeId,
         nodeType: NodeType.GROUP,
@@ -795,6 +834,32 @@ describe('RoadmapsService', () => {
         status: 422,
       });
       expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should throw 422 for milestone nodes', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.MILESTONE,
+        skillId: null,
+      });
+
+      await expect(service.getNodeQuiz(MOCK_USER_ID, roadmapId, nodeId)).rejects.toMatchObject({
+        status: 422,
+      });
+      expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should throw 500 when the seeded quiz catalog has fewer than 5 questions', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.REQUIRED,
+        skillId,
+      });
+      prisma.quizQuestion.findMany.mockResolvedValue(mockQuestions.slice(0, 4));
+
+      await expect(service.getNodeQuiz(MOCK_USER_ID, roadmapId, nodeId)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -1,10 +1,11 @@
-/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/unbound-method */
 import type { TestingModule } from '@nestjs/testing';
 
 import { Test } from '@nestjs/testing';
 import { NodeStatus, NodeType, RoleCategory } from '@repo/db/prisma/client';
 
 import {
+  AppNotFoundException,
   DeadlineInPastException,
   RoadmapGenerationUnavailableException,
   RoadmapNotFoundException,
@@ -110,7 +111,16 @@ describe('RoadmapsService', () => {
         RoadmapsService,
         {
           provide: PrismaService,
-          useValue: prismaMock,
+          useValue: {
+            skill: { findMany: jest.fn().mockResolvedValue(MOCK_SKILLS) },
+            skillPrerequisite: {
+              findMany: jest.fn().mockResolvedValue(MOCK_PRISMA_SKILL_PREREQUISITES),
+            },
+            roadmapNode: { findMany: jest.fn() },
+            $transaction: jest
+              .fn()
+              .mockImplementation(async (fn: (tx: typeof txMock) => unknown) => await fn(txMock)),
+          },
         },
         {
           provide: AiService,
@@ -706,6 +716,85 @@ describe('RoadmapsService', () => {
       await expect(service.deleteByIdForOwner('user-1', 'roadmap-1')).rejects.toThrow(
         RoadmapNotFoundException,
       );
+    });
+  });
+
+  describe('getNodeQuiz', () => {
+    const nodeId = 'node-1';
+    const roadmapId = 'roadmap-1';
+    const skillId = 'skill-1';
+    const mockQuestions = Array.from({ length: 5 }, (_, index) => ({
+      id: `question-${index + 1}`,
+      questionText: 'Which HTTP method is idempotent but not safe?',
+      optionA: 'GET',
+      optionB: 'POST',
+      optionC: 'PUT',
+      optionD: 'PATCH',
+    }));
+
+    it('should return exactly 5 public quiz questions for a leaf node', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.REQUIRED,
+        skillId,
+      });
+      prisma.quizQuestion.findMany.mockResolvedValue(mockQuestions);
+
+      const result = await service.getNodeQuiz(MOCK_USER_ID, roadmapId, nodeId);
+
+      expect(prisma.roadmapNode.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: nodeId,
+          roadmapId,
+          roadmap: { userId: MOCK_USER_ID },
+        },
+        select: {
+          id: true,
+          nodeType: true,
+          skillId: true,
+        },
+      });
+      expect(prisma.quizQuestion.findMany).toHaveBeenCalledWith({
+        where: { skillId },
+        select: {
+          id: true,
+          questionText: true,
+          optionA: true,
+          optionB: true,
+          optionC: true,
+          optionD: true,
+        },
+        orderBy: { createdAt: 'asc' },
+        take: 5,
+      });
+      expect(JSON.stringify(result)).not.toContain('correctOption');
+      expect(result).toEqual({
+        nodeId,
+        skillId,
+        questions: mockQuestions,
+      });
+    });
+
+    it('should throw 404 when node is not found in the roadmap', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue(null);
+
+      await expect(service.getNodeQuiz(MOCK_USER_ID, roadmapId, nodeId)).rejects.toThrow(
+        AppNotFoundException,
+      );
+      expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should throw 422 for group or milestone nodes', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.GROUP,
+        skillId: null,
+      });
+
+      await expect(service.getNodeQuiz(MOCK_USER_ID, roadmapId, nodeId)).rejects.toMatchObject({
+        status: 422,
+      });
+      expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds an API endpoint to fetch public quiz questions for a roadmap leaf node.

## Related Issue

Closes #43

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added `GET /roadmaps/:roadmapId/nodes/:nodeId/quiz`.
- Fetches 5 quiz questions from the node skill’s pre-seeded quiz bank.
- Excludes `correctOption` from the response.
- Returns `404` when the node is not found or does not belong to the roadmap.
- Returns `422` when the node is a group or milestone.
- Added unit tests for controller and service behavior.

## How to Test

Steps to verify:

1. Run the API tests:
   ```bash
   pnpm --filter api test -- roadmaps
   ```
2. Build the API:
   ```bash
   pnpm --filter api build
   ```
3. Test with Postman:
   ```http
   GET /roadmaps/{roadmapId}/nodes/{nodeId}/quiz
   ```
   Use a `REQUIRED` or `OPTIONAL` node with a valid `skillId`.
4. Confirm the response contains `nodeId`, `skillId`, and `questions`, and does not include `correctOption`.

## Screenshots (if FE)

N/A

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

`pnpm --filter api lint` still reports existing warnings in unrelated test files, but no warnings were introduced in the roadmaps files changed by this PR.