### PR TITLE
Feature/44 submit quiz score and progress

### DIFF
--- a/apps/api/src/modules/roadmaps/dto/submit-quiz.dto.ts
+++ b/apps/api/src/modules/roadmaps/dto/submit-quiz.dto.ts
@@ -1,0 +1,32 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsIn,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
+
+const toUppercaseString = ({ value }): unknown =>
+  typeof value === 'string' ? value.toUpperCase() : value;
+
+export class QuizAnswerDto {
+  @IsUUID()
+  questionId!: string;
+
+  @Transform(toUppercaseString)
+  @IsString()
+  @IsIn(['A', 'B', 'C', 'D'])
+  selectedOption!: string;
+}
+
+export class SubmitQuizDto {
+  @IsArray()
+  @ArrayMinSize(5)
+  @ArrayMaxSize(5)
+  @ValidateNested({ each: true })
+  @Type(() => QuizAnswerDto)
+  answers!: QuizAnswerDto[];
+}

--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -16,6 +16,7 @@ import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.d
 import { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
 import { ListRoadmapsQueryDto } from './dto/list-roadmaps-query.dto';
 import { RoadmapNodesFilterDto } from './dto/roadmap-nodes-filter.dto';
+import { SubmitQuizDto } from './dto/submit-quiz.dto';
 import { RoadmapsService } from './roadmaps.service';
 
 @Controller('roadmaps')
@@ -83,5 +84,21 @@ export class RoadmapsController {
     @Param('nodeId') nodeId: string,
   ) {
     return this.roadmapsService.getNodeQuiz(user.id, roadmapId, nodeId);
+  }
+
+  /**
+   * POST /roadmaps/:roadmapId/nodes/:nodeId/quiz/submit
+   *
+   * Scores a required/optional leaf node quiz and updates the user's node progress.
+   */
+  @Post(':roadmapId/nodes/:nodeId/quiz/submit')
+  @HttpCode(HttpStatus.OK)
+  async submitNodeQuiz(
+    @CurrentUser() user: RequestUser,
+    @Param('roadmapId') roadmapId: string,
+    @Param('nodeId') nodeId: string,
+    @Body() dto: SubmitQuizDto,
+  ) {
+    return this.roadmapsService.submitNodeQuiz(user.id, roadmapId, nodeId, dto);
   }
 }

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, UnprocessableEntityException } from '@nestjs/common
 import { NodeType, type Prisma, type Roadmap } from '@repo/db/prisma/client';
 
 import {
+  AppBadRequestException,
   AppNotFoundException,
   DeadlineInPastException,
   InternalServerErrorException,
@@ -14,8 +15,13 @@ import type { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
 import type { ListRoadmapsQueryDto } from './dto/list-roadmaps-query.dto';
 import type { RoadmapNodesFilterDto } from './dto/roadmap-nodes-filter.dto';
 import type { PaginatedRoadmapsResponseDto, RoadmapResponseDto } from './dto/roadmap-response.dto';
+import type { SubmitQuizDto } from './dto/submit-quiz.dto';
 import type { AiNode, AiRoadmapOutput, FlatNode } from './types/ai-roadmap.types';
-import type { RoadmapNodeQuizResponse } from './types/roadmap-node-quiz.types';
+import type {
+  QuizOption,
+  RoadmapNodeQuizResponse,
+  SubmitQuizResponse,
+} from './types/roadmap-node-quiz.types';
 import type { RoadmapNodesListResponse } from './types/roadmap-nodes.types';
 
 import { AiService } from '../ai/ai.service';
@@ -29,6 +35,8 @@ const FEASIBILITY_THRESHOLD = 0.15;
 
 const LEAF_NODE_TYPES: NodeType[] = [NodeType.REQUIRED, NodeType.OPTIONAL];
 const NODE_QUIZ_QUESTION_COUNT = 5;
+const QUIZ_PASSING_SCORE_PCT = 60;
+const QUIZ_REVIEW_SUGGESTION = 'You should review this part before continuing.';
 
 const ROADMAP_SELECT = {
   deadlineDate: true,
@@ -54,6 +62,8 @@ type DecimalLike = {
 
 const toNumberOrNull = (value: Prisma.Decimal | number | null) =>
   value === null ? null : Number(value);
+
+const toQuizOption = (value: string): QuizOption => value.toLowerCase() as QuizOption;
 
 @Injectable()
 export class RoadmapsService {
@@ -258,6 +268,121 @@ export class RoadmapsService {
         optionC: question.optionC,
         optionD: question.optionD,
       })),
+    };
+  }
+
+  async submitNodeQuiz(
+    userId: string,
+    roadmapId: string,
+    nodeId: string,
+    dto: SubmitQuizDto,
+  ): Promise<SubmitQuizResponse> {
+    const node = await this.prisma.roadmapNode.findFirst({
+      where: {
+        id: nodeId,
+        roadmapId,
+        roadmap: { userId },
+      },
+      select: {
+        id: true,
+        nodeType: true,
+        skillId: true,
+      },
+    });
+
+    if (!node) {
+      throw new AppNotFoundException('Roadmap node not found');
+    }
+
+    if (!LEAF_NODE_TYPES.includes(node.nodeType) || !node.skillId) {
+      throw new UnprocessableEntityException({
+        code: 42200,
+        message: 'Quiz is only available for required or optional leaf nodes',
+      });
+    }
+
+    const questions = await this.prisma.quizQuestion.findMany({
+      where: { skillId: node.skillId },
+      select: {
+        id: true,
+        correctOption: true,
+      },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: NODE_QUIZ_QUESTION_COUNT,
+    });
+
+    if (questions.length !== NODE_QUIZ_QUESTION_COUNT) {
+      this.logger.error(
+        `Expected ${NODE_QUIZ_QUESTION_COUNT} quiz questions for skill ` +
+          `${node.skillId}, got ${questions.length}`,
+      );
+      throw new InternalServerErrorException('Quiz question catalog is incomplete for this skill');
+    }
+
+    this.assertStrictQuizSubmission(
+      dto.answers,
+      questions.map((question) => question.id),
+    );
+
+    const answerByQuestionId = new Map(
+      dto.answers.map((answer) => [answer.questionId, answer.selectedOption.toUpperCase()]),
+    );
+    const results = questions.map((question) => {
+      const selectedOption = answerByQuestionId.get(question.id)!;
+      const correctOption = question.correctOption.toUpperCase();
+
+      return {
+        questionId: question.id,
+        selectedOption: toQuizOption(selectedOption),
+        correctOption: toQuizOption(correctOption),
+        isCorrect: selectedOption === correctOption,
+      };
+    });
+    const correctCount = results.filter((result) => result.isCorrect).length;
+    const totalQuestions = questions.length;
+    const scorePct = (correctCount / totalQuestions) * 100;
+    const passed = scorePct >= QUIZ_PASSING_SCORE_PCT;
+
+    const updatedProgress = await this.prisma.$transaction(async (tx) =>
+      tx.userNodeProgress.update({
+        where: {
+          userId_roadmapNodeId: {
+            userId,
+            roadmapNodeId: node.id,
+          },
+        },
+        data: {
+          quizScorePct: scorePct,
+          quizPassed: passed,
+        },
+        select: {
+          id: true,
+          roadmapNodeId: true,
+          status: true,
+          startedAt: true,
+          completedAt: true,
+          quizScorePct: true,
+          quizPassed: true,
+        },
+      }),
+    );
+
+    return {
+      scorePct,
+      passed,
+      correctCount,
+      totalQuestions,
+      results,
+      nodeProgress: {
+        id: updatedProgress.id,
+        roadmapNodeId: updatedProgress.roadmapNodeId,
+        status: updatedProgress.status,
+        startedAt: updatedProgress.startedAt,
+        completedAt: updatedProgress.completedAt,
+        quizScorePct: toNumberOrNull(updatedProgress.quizScorePct),
+        quizPassed: updatedProgress.quizPassed,
+      },
+      suggestion: passed ? null : QUIZ_REVIEW_SUGGESTION,
     };
   }
 
@@ -656,6 +781,31 @@ export class RoadmapsService {
         .trim();
     }
     return trimmed;
+  }
+
+  private assertStrictQuizSubmission(
+    answers: SubmitQuizDto['answers'],
+    expectedQuestionIds: string[],
+  ): void {
+    if (answers.length !== NODE_QUIZ_QUESTION_COUNT) {
+      throw new AppBadRequestException('Quiz submission must include exactly 5 answers');
+    }
+
+    const submittedQuestionIds = answers.map((answer) => answer.questionId);
+    const uniqueSubmittedQuestionIds = new Set(submittedQuestionIds);
+
+    if (uniqueSubmittedQuestionIds.size !== submittedQuestionIds.length) {
+      throw new AppBadRequestException('Quiz submission contains duplicate question answers');
+    }
+
+    const expectedQuestionIdSet = new Set(expectedQuestionIds);
+    const hasOnlyExpectedQuestions = submittedQuestionIds.every((questionId) =>
+      expectedQuestionIdSet.has(questionId),
+    );
+
+    if (!hasOnlyExpectedQuestions) {
+      throw new AppBadRequestException('Quiz submission contains unknown question answers');
+    }
   }
 
   async getByIdForOwner(userId: string, roadmapId: string): Promise<RoadmapResponseDto> {

--- a/apps/api/src/modules/roadmaps/types/roadmap-node-quiz.types.ts
+++ b/apps/api/src/modules/roadmaps/types/roadmap-node-quiz.types.ts
@@ -1,3 +1,5 @@
+import type { UserNodeProgressResponse } from './roadmap-nodes.types';
+
 export interface QuizQuestionPublic {
   id: string;
   questionText: string;
@@ -11,4 +13,23 @@ export interface RoadmapNodeQuizResponse {
   nodeId: string;
   skillId: string;
   questions: QuizQuestionPublic[];
+}
+
+export type QuizOption = 'a' | 'b' | 'c' | 'd';
+
+export interface SubmitQuizQuestionResult {
+  questionId: string;
+  selectedOption: QuizOption;
+  correctOption: QuizOption;
+  isCorrect: boolean;
+}
+
+export interface SubmitQuizResponse {
+  scorePct: number;
+  passed: boolean;
+  correctCount: number;
+  totalQuestions: number;
+  results: SubmitQuizQuestionResult[];
+  nodeProgress: UserNodeProgressResponse;
+  suggestion: string | null;
 }

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -15,6 +15,7 @@ describe('RoadmapsController', () => {
     getNodeQuiz: jest.fn(),
     listNodes: jest.fn(),
     listUserRoadmaps: jest.fn(),
+    submitNodeQuiz: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -156,6 +157,54 @@ describe('RoadmapsController', () => {
     const result = await controller.getNodeQuiz(mockUser, 'roadmap-1', 'node-1');
 
     expect(mockRoadmapsService.getNodeQuiz).toHaveBeenCalledWith('user-1', 'roadmap-1', 'node-1');
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('should call submitNodeQuiz and return response', async () => {
+    const mockUser = {
+      id: 'user-1',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      role: 'USER',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    const dto = {
+      answers: [
+        { questionId: 'question-1', selectedOption: 'A' },
+        { questionId: 'question-2', selectedOption: 'B' },
+        { questionId: 'question-3', selectedOption: 'C' },
+        { questionId: 'question-4', selectedOption: 'D' },
+        { questionId: 'question-5', selectedOption: 'A' },
+      ],
+    };
+    const mockResponse = {
+      scorePct: 100,
+      passed: true,
+      correctCount: 5,
+      totalQuestions: 5,
+      results: [],
+      nodeProgress: {
+        id: 'progress-1',
+        roadmapNodeId: 'node-1',
+        status: 'IN_PROGRESS',
+        startedAt: null,
+        completedAt: null,
+        quizScorePct: 100,
+        quizPassed: true,
+      },
+      suggestion: null,
+    };
+
+    mockRoadmapsService.submitNodeQuiz.mockResolvedValue(mockResponse);
+
+    const result = await controller.submitNodeQuiz(mockUser, 'roadmap-1', 'node-1', dto);
+
+    expect(mockRoadmapsService.submitNodeQuiz).toHaveBeenCalledWith(
+      'user-1',
+      'roadmap-1',
+      'node-1',
+      dto,
+    );
     expect(result).toEqual(mockResponse);
   });
 });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -33,6 +33,7 @@ function makeTxMock() {
     roadmapNode: { createMany: jest.fn().mockResolvedValue({ count: 19 }) },
     userNodeProgress: {
       createMany: jest.fn().mockResolvedValue({ count: 19 }),
+      update: jest.fn(),
       updateMany: jest.fn().mockResolvedValue({ count: 4 }),
     },
   };
@@ -51,19 +52,20 @@ interface RoadmapNodeQuizSelection {
   skillId: string | null;
 }
 
-interface QuizQuestionPublicRecord {
+interface QuizQuestionRecord {
   id: string;
   questionText: string;
   optionA: string;
   optionB: string;
   optionC: string;
   optionD: string;
+  correctOption: string;
 }
 
 interface RoadmapsPrismaMock {
   $transaction: AsyncMock<unknown, [unknown]>;
   quizQuestion: {
-    findMany: AsyncMock<QuizQuestionPublicRecord[]>;
+    findMany: AsyncMock<QuizQuestionRecord[]>;
   };
   roadmap: {
     count: AsyncMock<number>;
@@ -100,7 +102,7 @@ const createPrismaMock = (txMock: TransactionMock): RoadmapsPrismaMock => ({
     return transactionCallback(txMock);
   }),
   quizQuestion: {
-    findMany: jest.fn<Promise<QuizQuestionPublicRecord[]>, unknown[]>(),
+    findMany: jest.fn<Promise<QuizQuestionRecord[]>, unknown[]>(),
   },
   roadmap: {
     count: jest.fn<Promise<number>, unknown[]>(),
@@ -125,11 +127,12 @@ const createPrismaMock = (txMock: TransactionMock): RoadmapsPrismaMock => ({
 describe('RoadmapsService', () => {
   let service: RoadmapsService;
   let prisma: RoadmapsPrismaMock;
+  let txMock: TransactionMock;
   let aiService: jest.Mocked<AiService>;
   let dagreLayout: jest.Mocked<DagreLayoutService>;
 
   beforeEach(async () => {
-    const txMock = makeTxMock();
+    txMock = makeTxMock();
     const prismaMock = createPrismaMock(txMock);
 
     const module: TestingModule = await Test.createTestingModule({
@@ -860,6 +863,318 @@ describe('RoadmapsService', () => {
       await expect(service.getNodeQuiz(MOCK_USER_ID, roadmapId, nodeId)).rejects.toThrow(
         InternalServerErrorException,
       );
+    });
+  });
+
+  describe('submitNodeQuiz', () => {
+    const nodeId = 'node-1';
+    const roadmapId = 'roadmap-1';
+    const skillId = 'skill-1';
+    const mockQuestions = [
+      { id: 'question-1', correctOption: 'A' },
+      { id: 'question-2', correctOption: 'B' },
+      { id: 'question-3', correctOption: 'C' },
+      { id: 'question-4', correctOption: 'D' },
+      { id: 'question-5', correctOption: 'A' },
+    ].map((question) => ({
+      ...question,
+      questionText: 'Question text',
+      optionA: 'A',
+      optionB: 'B',
+      optionC: 'C',
+      optionD: 'D',
+    }));
+    const submitDto = {
+      answers: [
+        { questionId: 'question-1', selectedOption: 'a' },
+        { questionId: 'question-2', selectedOption: 'B' },
+        { questionId: 'question-3', selectedOption: 'C' },
+        { questionId: 'question-4', selectedOption: 'D' },
+        { questionId: 'question-5', selectedOption: 'B' },
+      ],
+    };
+    const updatedProgress = {
+      id: 'progress-1',
+      roadmapNodeId: nodeId,
+      status: NodeStatus.IN_PROGRESS,
+      startedAt: new Date('2026-01-01T00:00:00Z'),
+      completedAt: null,
+      quizScorePct: createDecimal(80),
+      quizPassed: true,
+    };
+
+    beforeEach(() => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.REQUIRED,
+        skillId,
+      });
+      prisma.quizQuestion.findMany.mockResolvedValue(mockQuestions);
+      txMock.userNodeProgress.update.mockResolvedValue(updatedProgress);
+    });
+
+    it('should score answers, reveal correct options, and return updated node progress', async () => {
+      const result = await service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, submitDto);
+
+      expect(prisma.roadmapNode.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: nodeId,
+          roadmapId,
+          roadmap: { userId: MOCK_USER_ID },
+        },
+        select: {
+          id: true,
+          nodeType: true,
+          skillId: true,
+        },
+      });
+      expect(prisma.quizQuestion.findMany).toHaveBeenCalledWith({
+        where: { skillId },
+        select: {
+          id: true,
+          correctOption: true,
+        },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        take: 5,
+      });
+      expect(txMock.userNodeProgress.update).toHaveBeenCalledWith({
+        where: {
+          userId_roadmapNodeId: {
+            userId: MOCK_USER_ID,
+            roadmapNodeId: nodeId,
+          },
+        },
+        data: {
+          quizScorePct: 80,
+          quizPassed: true,
+        },
+        select: {
+          id: true,
+          roadmapNodeId: true,
+          status: true,
+          startedAt: true,
+          completedAt: true,
+          quizScorePct: true,
+          quizPassed: true,
+        },
+      });
+      expect(result).toEqual({
+        scorePct: 80,
+        passed: true,
+        correctCount: 4,
+        totalQuestions: 5,
+        results: [
+          { questionId: 'question-1', selectedOption: 'a', correctOption: 'a', isCorrect: true },
+          { questionId: 'question-2', selectedOption: 'b', correctOption: 'b', isCorrect: true },
+          { questionId: 'question-3', selectedOption: 'c', correctOption: 'c', isCorrect: true },
+          { questionId: 'question-4', selectedOption: 'd', correctOption: 'd', isCorrect: true },
+          { questionId: 'question-5', selectedOption: 'b', correctOption: 'a', isCorrect: false },
+        ],
+        nodeProgress: {
+          id: 'progress-1',
+          roadmapNodeId: nodeId,
+          status: NodeStatus.IN_PROGRESS,
+          startedAt: new Date('2026-01-01T00:00:00Z'),
+          completedAt: null,
+          quizScorePct: 80,
+          quizPassed: true,
+        },
+        suggestion: null,
+      });
+    });
+
+    it('should pass at exactly 60 percent', async () => {
+      txMock.userNodeProgress.update.mockResolvedValue({
+        ...updatedProgress,
+        quizScorePct: createDecimal(60),
+        quizPassed: true,
+      });
+
+      const result = await service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+        answers: [
+          { questionId: 'question-1', selectedOption: 'A' },
+          { questionId: 'question-2', selectedOption: 'B' },
+          { questionId: 'question-3', selectedOption: 'C' },
+          { questionId: 'question-4', selectedOption: 'A' },
+          { questionId: 'question-5', selectedOption: 'B' },
+        ],
+      });
+
+      expect(result.scorePct).toBe(60);
+      expect(result.passed).toBe(true);
+      expect(txMock.userNodeProgress.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            quizScorePct: 60,
+            quizPassed: true,
+          },
+        }),
+      );
+    });
+
+    it('should return a suggestion and quizPassed=false when score is below 60', async () => {
+      txMock.userNodeProgress.update.mockResolvedValue({
+        ...updatedProgress,
+        quizScorePct: createDecimal(40),
+        quizPassed: false,
+      });
+
+      const result = await service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+        answers: [
+          { questionId: 'question-1', selectedOption: 'A' },
+          { questionId: 'question-2', selectedOption: 'B' },
+          { questionId: 'question-3', selectedOption: 'A' },
+          { questionId: 'question-4', selectedOption: 'A' },
+          { questionId: 'question-5', selectedOption: 'B' },
+        ],
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          scorePct: 40,
+          passed: false,
+          correctCount: 2,
+          suggestion: 'You should review this part before continuing.',
+        }),
+      );
+      expect(result.nodeProgress.quizPassed).toBe(false);
+    });
+
+    it('should overwrite the previous quiz score on re-submission', async () => {
+      txMock.userNodeProgress.update
+        .mockResolvedValueOnce({
+          ...updatedProgress,
+          quizScorePct: createDecimal(100),
+          quizPassed: true,
+        })
+        .mockResolvedValueOnce({
+          ...updatedProgress,
+          quizScorePct: createDecimal(40),
+          quizPassed: false,
+        });
+
+      await service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+        answers: [
+          { questionId: 'question-1', selectedOption: 'A' },
+          { questionId: 'question-2', selectedOption: 'B' },
+          { questionId: 'question-3', selectedOption: 'C' },
+          { questionId: 'question-4', selectedOption: 'D' },
+          { questionId: 'question-5', selectedOption: 'A' },
+        ],
+      });
+      const secondResult = await service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+        answers: [
+          { questionId: 'question-1', selectedOption: 'A' },
+          { questionId: 'question-2', selectedOption: 'B' },
+          { questionId: 'question-3', selectedOption: 'A' },
+          { questionId: 'question-4', selectedOption: 'A' },
+          { questionId: 'question-5', selectedOption: 'B' },
+        ],
+      });
+
+      expect(txMock.userNodeProgress.update).toHaveBeenCalledTimes(2);
+      expect(txMock.userNodeProgress.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: {
+            quizScorePct: 40,
+            quizPassed: false,
+          },
+        }),
+      );
+      expect(secondResult.nodeProgress.quizScorePct).toBe(40);
+    });
+
+    it('should throw 404 when node is not found in the roadmap', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, submitDto),
+      ).rejects.toThrow(AppNotFoundException);
+      expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
+      expect(txMock.userNodeProgress.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw 422 for group nodes', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.GROUP,
+        skillId: null,
+      });
+
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, submitDto),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should throw 422 for milestone nodes', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({
+        id: nodeId,
+        nodeType: NodeType.MILESTONE,
+        skillId: null,
+      });
+
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, submitDto),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(prisma.quizQuestion.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should throw 500 when the seeded quiz catalog has fewer than 5 questions', async () => {
+      prisma.quizQuestion.findMany.mockResolvedValue(mockQuestions.slice(0, 4));
+
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, submitDto),
+      ).rejects.toThrow(InternalServerErrorException);
+      expect(txMock.userNodeProgress.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw 400 for duplicate question ids', async () => {
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+          answers: [
+            { questionId: 'question-1', selectedOption: 'A' },
+            { questionId: 'question-1', selectedOption: 'B' },
+            { questionId: 'question-3', selectedOption: 'C' },
+            { questionId: 'question-4', selectedOption: 'D' },
+            { questionId: 'question-5', selectedOption: 'A' },
+          ],
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(txMock.userNodeProgress.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw 400 for missing question ids', async () => {
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+          answers: submitDto.answers.slice(0, 4),
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(txMock.userNodeProgress.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw 400 for extra question ids', async () => {
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+          answers: [...submitDto.answers, { questionId: 'question-6', selectedOption: 'A' }],
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(txMock.userNodeProgress.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw 400 for unknown question ids', async () => {
+      await expect(
+        service.submitNodeQuiz(MOCK_USER_ID, roadmapId, nodeId, {
+          answers: [
+            { questionId: 'question-1', selectedOption: 'A' },
+            { questionId: 'question-2', selectedOption: 'B' },
+            { questionId: 'question-3', selectedOption: 'C' },
+            { questionId: 'question-4', selectedOption: 'D' },
+            { questionId: 'unknown-question', selectedOption: 'A' },
+          ],
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(txMock.userNodeProgress.update).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds the post-node quiz submission endpoint for scoring leaf-node quizzes. The endpoint validates a strict 5-answer submission, calculates the score, updates `quizScorePct` and `quizPassed` on `user_node_progress`, and returns per-question results with correct answers revealed.

## Related Issue

Closes #44

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added `POST /roadmaps/:roadmapId/nodes/:nodeId/quiz/submit`
- Added `SubmitQuizDto` for quiz answer validation
- Added submit quiz response/result types
- Scores quiz as `correctCount / totalQuestions * 100`
- Sets `quizPassed=true` when score is at least `60`
- Allows re-submission by overwriting previous quiz score fields
- Returns revealed `correctOption` per question
- Returns review suggestion when quiz is not passed
- Added unit tests for service and controller behavior

## How to Test

Steps to verify:

1. Start the API and authenticate as a user with a generated roadmap.
2. Fetch quiz questions:
   `GET /api/v1/roadmaps/:roadmapId/nodes/:nodeId/quiz`
3. Submit exactly 5 answers:
   `POST /api/v1/roadmaps/:roadmapId/nodes/:nodeId/quiz/submit`
4. Verify the response includes `scorePct`, `passed`, `correctCount`, `totalQuestions`, `results`, `nodeProgress`, and `suggestion`.
5. Submit again with different answers and verify `quizScorePct`/`quizPassed` are overwritten.
6. Verify invalid cases:
   - group/milestone node returns `422`
   - missing/duplicate/unknown/extra question IDs return `400`

Verification commands run:

```bash
pnpm --filter api test
pnpm --filter api lint
pnpm check-types
pnpm --filter api build
```

## Screenshots (if FE)

N/A

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

`pnpm --filter api check-types` could not be run because the API package does not define a `check-types` script. Root `pnpm check-types` and `pnpm --filter api build` were run instead.