### PR TITLE
Feature/42 roadmap progress summary

### DIFF
--- a/apps/api/src/modules/roadmaps/roadmaps.controller.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.controller.ts
@@ -13,6 +13,7 @@ import {
 
 import type { PaginatedRoadmapsResponseDto, RoadmapResponseDto } from './dto/roadmap-response.dto';
 import type { NodeDetailResponse } from './types/roadmap-nodes.types';
+import type { RoadmapProgressSummaryResponse } from './types/roadmap-progress.types';
 
 import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.decorator';
 import { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
@@ -74,6 +75,19 @@ export class RoadmapsController {
     @Param('nodeId') nodeId: string,
   ): Promise<NodeDetailResponse> {
     return this.roadmapsService.getNodeDetail(user.id, roadmapId, nodeId);
+  }
+
+  /**
+   * GET /roadmaps/:roadmapId/progress
+   *
+   * Returns completion %, streak, skill readiness, and timeline warning.
+   */
+  @Get(':roadmapId/progress')
+  async getProgressSummary(
+    @CurrentUser() user: RequestUser,
+    @Param('roadmapId') roadmapId: string,
+  ): Promise<RoadmapProgressSummaryResponse> {
+    return this.roadmapsService.getProgressSummary(user.id, roadmapId);
   }
 
   @Get(':roadmapId')

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -33,6 +33,10 @@ import type {
   RoadmapNodesListResponse,
   UpdateNodeProgressResponse,
 } from './types/roadmap-nodes.types';
+import type {
+  RoadmapProgressSummaryResponse,
+  TimelineWarningResponse,
+} from './types/roadmap-progress.types';
 
 import { AiService } from '../ai/ai.service';
 import { DagreLayoutService } from './dagre-layout.service';
@@ -43,6 +47,7 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
 /** Timeline warning threshold: warn when total > available * (1 + THRESHOLD). */
 const FEASIBILITY_THRESHOLD = 0.15;
 
+const PACE_WARNING_THRESHOLD_PCT = 15;
 const LEAF_NODE_TYPES: NodeType[] = [NodeType.REQUIRED, NodeType.OPTIONAL];
 const NODE_QUIZ_QUESTION_COUNT = 5;
 const QUIZ_PASSING_SCORE_PCT = 60;
@@ -96,6 +101,20 @@ type RoadmapNodeWithProgressRecord = {
     quizScorePct: Prisma.Decimal | number | null;
     quizPassed: boolean | null;
   }>;
+};
+
+type RoadmapProgressNodeRecord = {
+  id: string;
+  nodeType: NodeType;
+  estimatedHours: Prisma.Decimal | number | null;
+  userNodeProgress: Array<{
+    status: NodeStatus;
+  }>;
+};
+
+type DailyActivityRecord = {
+  activityDate: Date;
+  nodesCompleted: number;
 };
 
 const toNumberOrNull = (value: Prisma.Decimal | number | null) =>
@@ -207,6 +226,81 @@ export class RoadmapsService {
 
     return {
       nodes: nodes.map((node) => this.formatNodeWithProgress(node)),
+    };
+  }
+
+  async getProgressSummary(
+    userId: string,
+    roadmapId: string,
+  ): Promise<RoadmapProgressSummaryResponse> {
+    const roadmap = await this.prisma.roadmap.findFirst({
+      where: {
+        id: roadmapId,
+        isTemplate: false,
+        userId,
+      },
+      select: {
+        generatedAt: true,
+        hoursPerDay: true,
+        id: true,
+      },
+    });
+
+    if (!roadmap) {
+      throw new RoadmapNotFoundException(roadmapId);
+    }
+
+    const [nodes, dailyActivities] = await this.prisma.$transaction([
+      this.prisma.roadmapNode.findMany({
+        where: { roadmapId },
+        select: {
+          id: true,
+          nodeType: true,
+          estimatedHours: true,
+          userNodeProgress: {
+            where: { userId },
+            select: { status: true },
+          },
+        },
+      }),
+      this.prisma.dailyActivity.findMany({
+        where: { userId },
+        orderBy: [{ activityDate: 'desc' }, { id: 'asc' }],
+        select: {
+          activityDate: true,
+          nodesCompleted: true,
+        },
+      }),
+    ]);
+
+    const nodesTotal = nodes.length;
+    const completedNodes = nodes.filter((node) => this.isNodeCompleted(node));
+    const nodesCompleted = completedNodes.length;
+    const requiredLeafNodes = nodes.filter((node) => node.nodeType === NodeType.REQUIRED);
+    const requiredLeafNodesCompleted = requiredLeafNodes.filter((node) =>
+      this.isNodeCompleted(node),
+    ).length;
+    const completedHours = completedNodes.reduce(
+      (total, node) => total + (toNumberOrNull(node.estimatedHours) ?? 0),
+      0,
+    );
+    const hoursPerDay = toNumberOrNull(roadmap.hoursPerDay);
+
+    return {
+      roadmapId: roadmap.id,
+      completionPct: this.calculatePercent(nodesCompleted, nodesTotal),
+      streakDays: this.calculateStreakDays(dailyActivities),
+      skillReadinessPct: this.calculatePercent(
+        requiredLeafNodesCompleted,
+        requiredLeafNodes.length,
+      ),
+      nodesTotal,
+      nodesCompleted,
+      timelineWarning: this.calculateTimelineWarning(
+        roadmap.generatedAt,
+        hoursPerDay,
+        completedHours,
+      ),
     };
   }
 
@@ -937,6 +1031,95 @@ export class RoadmapsService {
           }
         : null,
     };
+  }
+
+  private isNodeCompleted(node: RoadmapProgressNodeRecord): boolean {
+    return node.userNodeProgress[0]?.status === NodeStatus.COMPLETED;
+  }
+
+  private calculatePercent(completed: number, total: number): number {
+    if (total === 0) {
+      return 0;
+    }
+
+    return this.roundToOne((completed / total) * 100);
+  }
+
+  private calculateStreakDays(dailyActivities: DailyActivityRecord[], now = new Date()): number {
+    const activeDateKeys = new Set(
+      dailyActivities
+        .filter((activity) => activity.nodesCompleted > 0)
+        .map((activity) => this.toUtcDateKey(activity.activityDate)),
+    );
+    const todayKey = this.toUtcDateKey(now);
+    const startDate = new Date(this.toUtcMidnightMs(now));
+
+    if (!activeDateKeys.has(todayKey)) {
+      startDate.setUTCDate(startDate.getUTCDate() - 1);
+    }
+
+    let streakDays = 0;
+    const cursor = new Date(startDate);
+
+    while (activeDateKeys.has(this.toUtcDateKey(cursor))) {
+      streakDays += 1;
+      cursor.setUTCDate(cursor.getUTCDate() - 1);
+    }
+
+    return streakDays;
+  }
+
+  private calculateTimelineWarning(
+    generatedAt: Date,
+    hoursPerDay: number | null,
+    completedHours: number,
+    now = new Date(),
+  ): TimelineWarningResponse | null {
+    if (!hoursPerDay || hoursPerDay <= 0 || Number.isNaN(generatedAt.getTime())) {
+      return null;
+    }
+
+    const daysElapsed =
+      Math.max(
+        1,
+        Math.floor((this.toUtcMidnightMs(now) - this.toUtcMidnightMs(generatedAt)) / MS_PER_DAY) +
+          1,
+      ) || 1;
+    const plannedHoursElapsed = daysElapsed * hoursPerDay;
+
+    if (plannedHoursElapsed <= 0) {
+      return null;
+    }
+
+    const hoursDeficit = Math.max(0, plannedHoursElapsed - completedHours);
+    const paceDeficitPct = this.roundToOne((hoursDeficit / plannedHoursElapsed) * 100);
+
+    if (paceDeficitPct < PACE_WARNING_THRESHOLD_PCT) {
+      return null;
+    }
+
+    const estimatedDelayDays = Math.ceil(hoursDeficit / hoursPerDay);
+
+    return {
+      isBehind: true,
+      paceDeficitPct,
+      estimatedDelayDays,
+      message:
+        `You are ${paceDeficitPct}% behind pace - projected delay is about ` +
+        `${estimatedDelayDays} day(s).`,
+    };
+  }
+
+  private roundToOne(value: number): number {
+    return Math.round(value * 10) / 10;
+  }
+
+  private toUtcDateKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+  }
+
+  private toUtcMidnightMs(date: Date): number {
+    return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
   }
 
   private formatRoadmap(roadmap: SelectedRoadmap): RoadmapResponseDto {

--- a/apps/api/src/modules/roadmaps/types/roadmap-progress.types.ts
+++ b/apps/api/src/modules/roadmaps/types/roadmap-progress.types.ts
@@ -1,0 +1,16 @@
+export interface TimelineWarningResponse {
+  isBehind: boolean;
+  paceDeficitPct: number;
+  estimatedDelayDays: number;
+  message: string;
+}
+
+export interface RoadmapProgressSummaryResponse {
+  roadmapId: string;
+  completionPct: number;
+  streakDays: number;
+  skillReadinessPct: number;
+  nodesTotal: number;
+  nodesCompleted: number;
+  timelineWarning: TimelineWarningResponse | null;
+}

--- a/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.controller.spec.ts
@@ -15,6 +15,7 @@ describe('RoadmapsController', () => {
     getByIdForOwner: jest.fn(),
     getNodeDetail: jest.fn(),
     getNodeQuiz: jest.fn(),
+    getProgressSummary: jest.fn(),
     listNodes: jest.fn(),
     listUserRoadmaps: jest.fn(),
     submitNodeQuiz: jest.fn(),
@@ -153,6 +154,34 @@ describe('RoadmapsController', () => {
       const result = await controller.get(user, 'roadmap-1');
 
       expect(mockRoadmapsService.getByIdForOwner).toHaveBeenCalledWith('user-1', 'roadmap-1');
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('getProgressSummary', () => {
+    it('should call getProgressSummary and return response', async () => {
+      const user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        fullName: 'Test User',
+        role: 'USER',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      };
+      const response = {
+        roadmapId: 'roadmap-1',
+        completionPct: 40,
+        streakDays: 3,
+        skillReadinessPct: 50,
+        nodesTotal: 5,
+        nodesCompleted: 2,
+        timelineWarning: null,
+      };
+
+      mockRoadmapsService.getProgressSummary.mockResolvedValue(response);
+
+      const result = await controller.getProgressSummary(user, 'roadmap-1');
+
+      expect(mockRoadmapsService.getProgressSummary).toHaveBeenCalledWith('user-1', 'roadmap-1');
       expect(result).toEqual(response);
     });
   });

--- a/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
+++ b/apps/api/test/unit/roadmaps/roadmaps.service.spec.ts
@@ -124,6 +124,9 @@ type RoadmapNodeFindFirstSelection = RoadmapNodeQuizSelection | RoadmapNodeDetai
 
 interface RoadmapsPrismaMock {
   $transaction: AsyncMock<unknown, [unknown]>;
+  dailyActivity: {
+    findMany: AsyncMock<Array<{ activityDate: Date; nodesCompleted: number }>>;
+  };
   quizQuestion: {
     findMany: AsyncMock<QuizQuestionRecord[]>;
   };
@@ -169,6 +172,9 @@ const createPrismaMock = (txMock: TransactionMock): RoadmapsPrismaMock => ({
     const transactionCallback = input as TransactionCallback;
     return transactionCallback(txMock);
   }),
+  dailyActivity: {
+    findMany: jest.fn<Promise<Array<{ activityDate: Date; nodesCompleted: number }>>, unknown[]>(),
+  },
   quizQuestion: {
     findMany: jest.fn<Promise<QuizQuestionRecord[]>, unknown[]>(),
   },
@@ -624,6 +630,128 @@ describe('RoadmapsService', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('getProgressSummary', () => {
+    const roadmapId = 'roadmap-1';
+    const systemNow = new Date('2026-05-21T12:00:00Z');
+    const makeProgressNode = (
+      id: string,
+      nodeType: NodeType,
+      status: NodeStatus | null,
+      estimatedHours: number | null,
+    ) => ({
+      id,
+      nodeType,
+      estimatedHours,
+      userNodeProgress: status ? [{ status }] : [],
+    });
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(systemNow);
+      prisma.roadmap.findFirst.mockResolvedValue({
+        generatedAt: new Date('2026-05-20T03:00:00Z'),
+        hoursPerDay: createDecimal(2),
+        id: roadmapId,
+      });
+      prisma.dailyActivity.findMany.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should throw RoadmapNotFoundException when the roadmap is not found', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
+
+      await expect(service.getProgressSummary(MOCK_USER_ID, roadmapId)).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('should compute completion and skill readiness percentages', async () => {
+      prisma.roadmapNode.findMany.mockResolvedValue([
+        makeProgressNode('group-1', NodeType.GROUP, NodeStatus.COMPLETED, null),
+        makeProgressNode('required-1', NodeType.REQUIRED, NodeStatus.COMPLETED, 2),
+        makeProgressNode('required-2', NodeType.REQUIRED, NodeStatus.IN_PROGRESS, 8),
+        makeProgressNode('optional-1', NodeType.OPTIONAL, NodeStatus.COMPLETED, 3),
+        makeProgressNode('milestone-1', NodeType.MILESTONE, NodeStatus.LOCKED, null),
+      ]);
+
+      const result = await service.getProgressSummary(MOCK_USER_ID, roadmapId);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          roadmapId,
+          completionPct: 60,
+          skillReadinessPct: 50,
+          nodesTotal: 5,
+          nodesCompleted: 3,
+          timelineWarning: null,
+        }),
+      );
+    });
+
+    it('should compute streak from consecutive daily activity rows', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue({
+        generatedAt: new Date('2026-05-20T03:00:00Z'),
+        hoursPerDay: null,
+        id: roadmapId,
+      });
+      prisma.roadmapNode.findMany.mockResolvedValue([]);
+      prisma.dailyActivity.findMany.mockResolvedValue([
+        { activityDate: new Date('2026-05-20T00:00:00Z'), nodesCompleted: 1 },
+        { activityDate: new Date('2026-05-19T00:00:00Z'), nodesCompleted: 2 },
+        { activityDate: new Date('2026-05-18T00:00:00Z'), nodesCompleted: 1 },
+        { activityDate: new Date('2026-05-17T00:00:00Z'), nodesCompleted: 0 },
+        { activityDate: new Date('2026-05-16T00:00:00Z'), nodesCompleted: 1 },
+      ]);
+
+      const result = await service.getProgressSummary(MOCK_USER_ID, roadmapId);
+
+      expect(result.streakDays).toBe(3);
+      expect(result.completionPct).toBe(0);
+      expect(result.skillReadinessPct).toBe(0);
+    });
+
+    it('should return a timeline warning when pace deficit is at least 15 percent', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue({
+        generatedAt: new Date('2026-05-19T03:00:00Z'),
+        hoursPerDay: createDecimal(4),
+        id: roadmapId,
+      });
+      prisma.roadmapNode.findMany.mockResolvedValue([
+        makeProgressNode('required-1', NodeType.REQUIRED, NodeStatus.COMPLETED, 9),
+        makeProgressNode('required-2', NodeType.REQUIRED, NodeStatus.IN_PROGRESS, 4),
+      ]);
+
+      const result = await service.getProgressSummary(MOCK_USER_ID, roadmapId);
+
+      expect(result.timelineWarning).toEqual({
+        isBehind: true,
+        paceDeficitPct: 25,
+        estimatedDelayDays: 1,
+        message: 'You are 25% behind pace - projected delay is about 1 day(s).',
+      });
+    });
+
+    it('should return null timeline warning when on track', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue({
+        generatedAt: new Date('2026-05-19T03:00:00Z'),
+        hoursPerDay: createDecimal(4),
+        id: roadmapId,
+      });
+      prisma.roadmapNode.findMany.mockResolvedValue([
+        makeProgressNode('required-1', NodeType.REQUIRED, NodeStatus.COMPLETED, 11),
+        makeProgressNode('required-2', NodeType.REQUIRED, NodeStatus.IN_PROGRESS, 4),
+      ]);
+
+      const result = await service.getProgressSummary(MOCK_USER_ID, roadmapId);
+
+      expect(result.timelineWarning).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Description

Implements `GET /roadmaps/:roadmapId/progress` to return the three-layer roadmap progress summary required by FR-14 and FR-15.

## Related Issue

Closes #42

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added `RoadmapProgressSummaryResponse` and `TimelineWarningResponse` types.
- Added `GET /roadmaps/:roadmapId/progress` controller route.
- Implemented progress summary calculation for:
  - `completionPct`
  - `skillReadinessPct`
  - `streakDays`
  - `timelineWarning`
- Added unit tests for controller and service behavior.
- Kept response fields in camelCase and followed existing API module patterns.

## How to Test

Steps to verify:

1. Run API tests:
   ```bash
   pnpm --filter api test
   ```

2. Build API:
   ```bash
   pnpm --filter api build
   ```

3. Start the API and call the endpoint with an authenticated user:
   ```http
   GET /roadmaps/:roadmapId/progress
   ```

4. Verify the response includes:
   ```json
   {
     "roadmapId": "...",
     "completionPct": 0,
     "streakDays": 0,
     "skillReadinessPct": 0,
     "nodesTotal": 0,
     "nodesCompleted": 0,
     "timelineWarning": null
   }
   ```

## Screenshots (if FE)

N/A - backend API only.

<details>
<summary><strong>Expand</strong></summary>

<!-- START - Add images here -->
<img width="1433" height="740" alt="image" src="https://github.com/user-attachments/assets/baf24297-d260-4869-8f1f-2669c0c0090c" />

<!-- END -->

</details>

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes