### PR TITLE
Feature/45 get dashboard aggregated dashboard data

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { AiModule } from './modules/ai/ai.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
+import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { OnboardingModule } from './modules/onboarding/onboarding.module';
 import { PrismaModule } from './modules/prisma/prisma.module';
 import { RoadmapsModule } from './modules/roadmaps/roadmaps.module';
@@ -23,6 +24,7 @@ import { UserModule } from './modules/user/user.module';
     UserModule,
     OnboardingModule,
     RoadmapsModule,
+    DashboardModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/common/utils/streak-days.util.ts
+++ b/apps/api/src/common/utils/streak-days.util.ts
@@ -1,0 +1,36 @@
+export interface StreakActivityRecord {
+  activityDate: Date;
+  nodesCompleted: number;
+}
+
+const toUtcDateKey = (date: Date): string => date.toISOString().slice(0, 10);
+
+const toUtcMidnightMs = (date: Date): number =>
+  Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+
+export const calculateStreakDays = (
+  dailyActivities: StreakActivityRecord[],
+  now = new Date(),
+): number => {
+  const activeDateKeys = new Set(
+    dailyActivities
+      .filter((activity) => activity.nodesCompleted > 0)
+      .map((activity) => toUtcDateKey(activity.activityDate)),
+  );
+  const todayKey = toUtcDateKey(now);
+  const startDate = new Date(toUtcMidnightMs(now));
+
+  if (!activeDateKeys.has(todayKey)) {
+    startDate.setUTCDate(startDate.getUTCDate() - 1);
+  }
+
+  let streakDays = 0;
+  const cursor = new Date(startDate);
+
+  while (activeDateKeys.has(toUtcDateKey(cursor))) {
+    streakDays += 1;
+    cursor.setUTCDate(cursor.getUTCDate() - 1);
+  }
+
+  return streakDays;
+};

--- a/apps/api/src/modules/dashboard/dashboard.controller.ts
+++ b/apps/api/src/modules/dashboard/dashboard.controller.ts
@@ -9,6 +9,12 @@ import { DashboardService } from './dashboard.service';
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
+  /**
+   * GET /dashboard
+   *
+   * Returns the authenticated user's profile summary, active roadmap,
+   * streak, and recent activity.
+   */
   @Get()
   async getDashboard(@CurrentUser() user: RequestUser): Promise<DashboardResponse> {
     return this.dashboardService.getDashboard(user.id);

--- a/apps/api/src/modules/dashboard/dashboard.controller.ts
+++ b/apps/api/src/modules/dashboard/dashboard.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+
+import type { DashboardResponse } from './types/dashboard-response.types';
+
+import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.decorator';
+import { DashboardService } from './dashboard.service';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  async getDashboard(@CurrentUser() user: RequestUser): Promise<DashboardResponse> {
+    return this.dashboardService.getDashboard(user.id);
+  }
+}

--- a/apps/api/src/modules/dashboard/dashboard.module.ts
+++ b/apps/api/src/modules/dashboard/dashboard.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../prisma/prisma.module';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -1,0 +1,258 @@
+import { Injectable } from '@nestjs/common';
+import { NodeStatus, NodeType, type Prisma, type UserRole } from '@repo/db/prisma/client';
+
+import type { TimelineWarningResponse } from '@/modules/roadmaps/types/roadmap-progress.types';
+
+import { UserNotFoundException } from '@/common/exceptions/app.exceptions';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+
+import type {
+  DailyActivityEntryResponse,
+  DashboardResponse,
+} from './types/dashboard-response.types';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const PACE_WARNING_THRESHOLD_PCT = 15;
+const DASHBOARD_ACTIVITY_DAYS = 30;
+
+type DailyActivityRecord = {
+  activityDate: Date;
+  nodesCompleted: number;
+};
+
+type DashboardRoadmapNodeRecord = {
+  id: string;
+  nodeType: NodeType;
+  estimatedHours: Prisma.Decimal | number | null;
+  userNodeProgress: Array<{
+    status: NodeStatus;
+  }>;
+};
+
+type DashboardRoadmapRecord = {
+  id: string;
+  generatedAt: Date;
+  hoursPerDay: Prisma.Decimal | number | null;
+  nodes: DashboardRoadmapNodeRecord[];
+};
+
+const toNumberOrNull = (value: Prisma.Decimal | number | null) =>
+  value === null ? null : Number(value);
+
+@Injectable()
+export class DashboardService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getDashboard(userId: string): Promise<DashboardResponse> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        fullName: true,
+        role: true,
+        createdAt: true,
+        dailyActivity: {
+          orderBy: [{ activityDate: 'desc' }, { id: 'asc' }],
+          select: {
+            activityDate: true,
+            nodesCompleted: true,
+          },
+        },
+        roadmaps: {
+          where: { isTemplate: false },
+          orderBy: [{ generatedAt: 'desc' }, { id: 'asc' }],
+          take: 1,
+          select: {
+            id: true,
+            generatedAt: true,
+            hoursPerDay: true,
+            nodes: {
+              select: {
+                id: true,
+                nodeType: true,
+                estimatedHours: true,
+                userNodeProgress: {
+                  where: { userId },
+                  select: { status: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      throw new UserNotFoundException(userId);
+    }
+
+    const streakDays = this.calculateStreakDays(user.dailyActivity);
+    const activeRoadmap = user.roadmaps[0]
+      ? this.formatRoadmapProgressSummary(user.roadmaps[0], streakDays)
+      : null;
+
+    return {
+      user_profile: {
+        id: user.id,
+        email: user.email,
+        fullName: user.fullName,
+        role: this.formatRole(user.role),
+        createdAt: user.createdAt.toISOString(),
+      },
+      active_roadmap: activeRoadmap,
+      streak_days: streakDays,
+      activity_recent: this.formatRecentActivity(user.dailyActivity),
+    };
+  }
+
+  private formatRoadmapProgressSummary(
+    roadmap: DashboardRoadmapRecord,
+    streakDays: number,
+  ): DashboardResponse['active_roadmap'] {
+    const nodesTotal = roadmap.nodes.length;
+    const completedNodes = roadmap.nodes.filter((node) => this.isNodeCompleted(node));
+    const nodesCompleted = completedNodes.length;
+    const requiredLeafNodes = roadmap.nodes.filter((node) => node.nodeType === NodeType.REQUIRED);
+    const requiredLeafNodesCompleted = requiredLeafNodes.filter((node) =>
+      this.isNodeCompleted(node),
+    ).length;
+    const completedHours = completedNodes.reduce(
+      (total, node) => total + (toNumberOrNull(node.estimatedHours) ?? 0),
+      0,
+    );
+
+    return {
+      roadmapId: roadmap.id,
+      completionPct: this.calculatePercent(nodesCompleted, nodesTotal),
+      streakDays,
+      skillReadinessPct: this.calculatePercent(
+        requiredLeafNodesCompleted,
+        requiredLeafNodes.length,
+      ),
+      nodesTotal,
+      nodesCompleted,
+      timelineWarning: this.calculateTimelineWarning(
+        roadmap.generatedAt,
+        toNumberOrNull(roadmap.hoursPerDay),
+        completedHours,
+      ),
+    };
+  }
+
+  private formatRecentActivity(
+    dailyActivities: DailyActivityRecord[],
+    now = new Date(),
+  ): DailyActivityEntryResponse[] {
+    const nodesCompletedByDate = new Map(
+      dailyActivities.map((activity) => [
+        this.toUtcDateKey(activity.activityDate),
+        activity.nodesCompleted,
+      ]),
+    );
+    const todayMidnightMs = this.toUtcMidnightMs(now);
+
+    return Array.from({ length: DASHBOARD_ACTIVITY_DAYS }, (_, index) => {
+      const date = new Date(todayMidnightMs - (DASHBOARD_ACTIVITY_DAYS - 1 - index) * MS_PER_DAY);
+      const dateKey = this.toUtcDateKey(date);
+
+      return {
+        activity_date: dateKey,
+        nodes_completed: nodesCompletedByDate.get(dateKey) ?? 0,
+      };
+    });
+  }
+
+  private calculateStreakDays(dailyActivities: DailyActivityRecord[], now = new Date()): number {
+    const activeDateKeys = new Set(
+      dailyActivities
+        .filter((activity) => activity.nodesCompleted > 0)
+        .map((activity) => this.toUtcDateKey(activity.activityDate)),
+    );
+    const todayKey = this.toUtcDateKey(now);
+    const startDate = new Date(this.toUtcMidnightMs(now));
+
+    if (!activeDateKeys.has(todayKey)) {
+      startDate.setUTCDate(startDate.getUTCDate() - 1);
+    }
+
+    let streakDays = 0;
+    const cursor = new Date(startDate);
+
+    while (activeDateKeys.has(this.toUtcDateKey(cursor))) {
+      streakDays += 1;
+      cursor.setUTCDate(cursor.getUTCDate() - 1);
+    }
+
+    return streakDays;
+  }
+
+  private calculateTimelineWarning(
+    generatedAt: Date,
+    hoursPerDay: number | null,
+    completedHours: number,
+    now = new Date(),
+  ): TimelineWarningResponse | null {
+    if (!hoursPerDay || hoursPerDay <= 0 || Number.isNaN(generatedAt.getTime())) {
+      return null;
+    }
+
+    const daysElapsed =
+      Math.max(
+        1,
+        Math.floor((this.toUtcMidnightMs(now) - this.toUtcMidnightMs(generatedAt)) / MS_PER_DAY) +
+          1,
+      ) || 1;
+    const plannedHoursElapsed = daysElapsed * hoursPerDay;
+
+    if (plannedHoursElapsed <= 0) {
+      return null;
+    }
+
+    const hoursDeficit = Math.max(0, plannedHoursElapsed - completedHours);
+    const paceDeficitPct = this.roundToOne((hoursDeficit / plannedHoursElapsed) * 100);
+
+    if (paceDeficitPct < PACE_WARNING_THRESHOLD_PCT) {
+      return null;
+    }
+
+    const estimatedDelayDays = Math.ceil(hoursDeficit / hoursPerDay);
+
+    return {
+      isBehind: true,
+      paceDeficitPct,
+      estimatedDelayDays,
+      message:
+        `You are ${paceDeficitPct}% behind pace - projected delay is about ` +
+        `${estimatedDelayDays} day(s).`,
+    };
+  }
+
+  private isNodeCompleted(node: DashboardRoadmapNodeRecord): boolean {
+    return node.userNodeProgress[0]?.status === NodeStatus.COMPLETED;
+  }
+
+  private calculatePercent(completed: number, total: number): number {
+    if (total === 0) {
+      return 0;
+    }
+
+    return this.roundToOne((completed / total) * 100);
+  }
+
+  private roundToOne(value: number): number {
+    return Math.round(value * 10) / 10;
+  }
+
+  private toUtcDateKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+  }
+
+  private toUtcMidnightMs(date: Date): number {
+    return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  }
+
+  private formatRole(role: UserRole): string {
+    return role.toLowerCase();
+  }
+}

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -4,6 +4,7 @@ import { NodeStatus, NodeType, type Prisma, type UserRole } from '@repo/db/prism
 import type { TimelineWarningResponse } from '@/modules/roadmaps/types/roadmap-progress.types';
 
 import { UserNotFoundException } from '@/common/exceptions/app.exceptions';
+import { calculateStreakDays } from '@/common/utils/streak-days.util';
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
 import type {
@@ -87,7 +88,7 @@ export class DashboardService {
       throw new UserNotFoundException(userId);
     }
 
-    const streakDays = this.calculateStreakDays(user.dailyActivity);
+    const streakDays = calculateStreakDays(user.dailyActivity);
     const activeRoadmap = user.roadmaps[0]
       ? this.formatRoadmapProgressSummary(user.roadmaps[0], streakDays)
       : null;
@@ -161,30 +162,6 @@ export class DashboardService {
         nodes_completed: nodesCompletedByDate.get(dateKey) ?? 0,
       };
     });
-  }
-
-  private calculateStreakDays(dailyActivities: DailyActivityRecord[], now = new Date()): number {
-    const activeDateKeys = new Set(
-      dailyActivities
-        .filter((activity) => activity.nodesCompleted > 0)
-        .map((activity) => this.toUtcDateKey(activity.activityDate)),
-    );
-    const todayKey = this.toUtcDateKey(now);
-    const startDate = new Date(this.toUtcMidnightMs(now));
-
-    if (!activeDateKeys.has(todayKey)) {
-      startDate.setUTCDate(startDate.getUTCDate() - 1);
-    }
-
-    let streakDays = 0;
-    const cursor = new Date(startDate);
-
-    while (activeDateKeys.has(this.toUtcDateKey(cursor))) {
-      streakDays += 1;
-      cursor.setUTCDate(cursor.getUTCDate() - 1);
-    }
-
-    return streakDays;
   }
 
   private calculateTimelineWarning(

--- a/apps/api/src/modules/dashboard/types/dashboard-response.types.ts
+++ b/apps/api/src/modules/dashboard/types/dashboard-response.types.ts
@@ -1,0 +1,21 @@
+import type { RoadmapProgressSummaryResponse } from '@/modules/roadmaps/types/roadmap-progress.types';
+
+export interface DashboardUserProfileResponse {
+  id: string;
+  email: string;
+  fullName: string;
+  role: string;
+  createdAt: string;
+}
+
+export interface DailyActivityEntryResponse {
+  activity_date: string;
+  nodes_completed: number;
+}
+
+export interface DashboardResponse {
+  user_profile: DashboardUserProfileResponse;
+  active_roadmap: RoadmapProgressSummaryResponse | null;
+  streak_days: number;
+  activity_recent: DailyActivityEntryResponse[];
+}

--- a/apps/api/src/modules/roadmaps/roadmaps.service.ts
+++ b/apps/api/src/modules/roadmaps/roadmaps.service.ts
@@ -13,6 +13,7 @@ import {
   RoadmapNotFoundException,
   UserNodeProgressNotFoundException,
 } from '@/common/exceptions/app.exceptions';
+import { calculateStreakDays, type StreakActivityRecord } from '@/common/utils/streak-days.util';
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
 import type { GenerateRoadmapDto } from './dto/generate-roadmap.dto';
@@ -110,11 +111,6 @@ type RoadmapProgressNodeRecord = {
   userNodeProgress: Array<{
     status: NodeStatus;
   }>;
-};
-
-type DailyActivityRecord = {
-  activityDate: Date;
-  nodesCompleted: number;
 };
 
 const toNumberOrNull = (value: Prisma.Decimal | number | null) =>
@@ -289,7 +285,7 @@ export class RoadmapsService {
     return {
       roadmapId: roadmap.id,
       completionPct: this.calculatePercent(nodesCompleted, nodesTotal),
-      streakDays: this.calculateStreakDays(dailyActivities),
+      streakDays: calculateStreakDays(dailyActivities as StreakActivityRecord[]),
       skillReadinessPct: this.calculatePercent(
         requiredLeafNodesCompleted,
         requiredLeafNodes.length,
@@ -1043,30 +1039,6 @@ export class RoadmapsService {
     }
 
     return this.roundToOne((completed / total) * 100);
-  }
-
-  private calculateStreakDays(dailyActivities: DailyActivityRecord[], now = new Date()): number {
-    const activeDateKeys = new Set(
-      dailyActivities
-        .filter((activity) => activity.nodesCompleted > 0)
-        .map((activity) => this.toUtcDateKey(activity.activityDate)),
-    );
-    const todayKey = this.toUtcDateKey(now);
-    const startDate = new Date(this.toUtcMidnightMs(now));
-
-    if (!activeDateKeys.has(todayKey)) {
-      startDate.setUTCDate(startDate.getUTCDate() - 1);
-    }
-
-    let streakDays = 0;
-    const cursor = new Date(startDate);
-
-    while (activeDateKeys.has(this.toUtcDateKey(cursor))) {
-      streakDays += 1;
-      cursor.setUTCDate(cursor.getUTCDate() - 1);
-    }
-
-    return streakDays;
   }
 
   private calculateTimelineWarning(

--- a/apps/api/test/unit/dashboard/dashboard.controller.spec.ts
+++ b/apps/api/test/unit/dashboard/dashboard.controller.spec.ts
@@ -1,0 +1,61 @@
+import type { TestingModule } from '@nestjs/testing';
+
+import { Test } from '@nestjs/testing';
+
+import { DashboardController } from '@/modules/dashboard/dashboard.controller';
+import { DashboardService } from '@/modules/dashboard/dashboard.service';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+
+  const mockDashboardService = {
+    getDashboard: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [
+        {
+          provide: DashboardService,
+          useValue: mockDashboardService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DashboardController>(DashboardController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call getDashboard and return response', async () => {
+    const user = {
+      id: 'user-1',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      role: 'USER',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    const response = {
+      user_profile: {
+        id: user.id,
+        email: user.email,
+        fullName: user.fullName,
+        role: 'user',
+        createdAt: user.createdAt.toISOString(),
+      },
+      active_roadmap: null,
+      streak_days: 0,
+      activity_recent: [],
+    };
+
+    mockDashboardService.getDashboard.mockResolvedValue(response);
+
+    const result = await controller.getDashboard(user);
+
+    expect(mockDashboardService.getDashboard).toHaveBeenCalledWith('user-1');
+    expect(result).toEqual(response);
+  });
+});

--- a/apps/api/test/unit/dashboard/dashboard.service.spec.ts
+++ b/apps/api/test/unit/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,222 @@
+import type { TestingModule } from '@nestjs/testing';
+import type { NodeStatus, NodeType, UserRole } from '@repo/db/prisma/client';
+
+import { Test } from '@nestjs/testing';
+import { NodeStatus as NodeStatusValue, NodeType as NodeTypeValue } from '@repo/db/prisma/client';
+
+import { UserNotFoundException } from '@/common/exceptions/app.exceptions';
+import { DashboardService } from '@/modules/dashboard/dashboard.service';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+
+type AsyncMock<TResult, TArgs extends unknown[] = unknown[]> = jest.Mock<Promise<TResult>, TArgs>;
+
+interface DailyActivityRecord {
+  activityDate: Date;
+  nodesCompleted: number;
+}
+
+interface DashboardRoadmapNodeRecord {
+  id: string;
+  nodeType: NodeType;
+  estimatedHours: number | null;
+  userNodeProgress: Array<{ status: NodeStatus }>;
+}
+
+interface DashboardRoadmapRecord {
+  id: string;
+  generatedAt: Date;
+  hoursPerDay: number | null;
+  nodes: DashboardRoadmapNodeRecord[];
+}
+
+interface DashboardUserRecord {
+  id: string;
+  email: string;
+  fullName: string;
+  role: UserRole;
+  createdAt: Date;
+  dailyActivity: DailyActivityRecord[];
+  roadmaps: DashboardRoadmapRecord[];
+}
+
+interface DashboardPrismaMock {
+  user: {
+    findUnique: AsyncMock<DashboardUserRecord | null>;
+  };
+}
+
+const MOCK_USER_ID = 'user-1';
+const SYSTEM_NOW = new Date('2026-05-20T10:00:00Z');
+
+const createPrismaMock = (): DashboardPrismaMock => ({
+  user: {
+    findUnique: jest.fn<Promise<DashboardUserRecord | null>, unknown[]>(),
+  },
+});
+
+const expectObjectContaining = <T extends object>(value: T): T =>
+  expect.objectContaining(value) as T;
+
+const createUserRecord = (overrides: Partial<DashboardUserRecord> = {}): DashboardUserRecord => ({
+  id: MOCK_USER_ID,
+  email: 'test@example.com',
+  fullName: 'Test User',
+  role: 'USER' as UserRole,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  dailyActivity: [],
+  roadmaps: [],
+  ...overrides,
+});
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+  let prisma: DashboardPrismaMock;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(SYSTEM_NOW);
+
+    const prismaMock = createPrismaMock();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DashboardService>(DashboardService);
+    prisma = prismaMock;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('should query the current user dashboard payload with non-template roadmap only', async () => {
+    prisma.user.findUnique.mockResolvedValue(createUserRecord());
+
+    await service.getDashboard(MOCK_USER_ID);
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith(
+      expectObjectContaining({
+        where: { id: MOCK_USER_ID },
+        select: expectObjectContaining({
+          roadmaps: expectObjectContaining({
+            where: { isTemplate: false },
+            orderBy: [{ generatedAt: 'desc' }, { id: 'asc' }],
+            take: 1,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should return active_roadmap null when the user has no roadmap', async () => {
+    prisma.user.findUnique.mockResolvedValue(
+      createUserRecord({
+        dailyActivity: [{ activityDate: new Date('2026-05-19T00:00:00Z'), nodesCompleted: 1 }],
+      }),
+    );
+
+    const result = await service.getDashboard(MOCK_USER_ID);
+
+    expect(result.active_roadmap).toBeNull();
+    expect(result.streak_days).toBe(1);
+    expect(result.activity_recent).toHaveLength(30);
+    expect(result.activity_recent[0]).toEqual({
+      activity_date: '2026-04-21',
+      nodes_completed: 0,
+    });
+    expect(result.activity_recent[29]).toEqual({
+      activity_date: '2026-05-20',
+      nodes_completed: 0,
+    });
+  });
+
+  it('should include all progress layers for the most recent active roadmap', async () => {
+    prisma.user.findUnique.mockResolvedValue(
+      createUserRecord({
+        dailyActivity: [
+          { activityDate: new Date('2026-05-20T00:00:00Z'), nodesCompleted: 1 },
+          { activityDate: new Date('2026-05-19T00:00:00Z'), nodesCompleted: 2 },
+          { activityDate: new Date('2026-05-18T00:00:00Z'), nodesCompleted: 0 },
+        ],
+        roadmaps: [
+          {
+            id: 'roadmap-1',
+            generatedAt: new Date('2026-05-19T00:00:00Z'),
+            hoursPerDay: null,
+            nodes: [
+              {
+                id: 'group-1',
+                nodeType: NodeTypeValue.GROUP,
+                estimatedHours: null,
+                userNodeProgress: [{ status: NodeStatusValue.COMPLETED }],
+              },
+              {
+                id: 'required-1',
+                nodeType: NodeTypeValue.REQUIRED,
+                estimatedHours: 2,
+                userNodeProgress: [{ status: NodeStatusValue.COMPLETED }],
+              },
+              {
+                id: 'required-2',
+                nodeType: NodeTypeValue.REQUIRED,
+                estimatedHours: 4,
+                userNodeProgress: [{ status: NodeStatusValue.IN_PROGRESS }],
+              },
+              {
+                id: 'optional-1',
+                nodeType: NodeTypeValue.OPTIONAL,
+                estimatedHours: 3,
+                userNodeProgress: [{ status: NodeStatusValue.COMPLETED }],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const result = await service.getDashboard(MOCK_USER_ID);
+
+    expect(result.active_roadmap).toEqual({
+      roadmapId: 'roadmap-1',
+      completionPct: 75,
+      streakDays: 2,
+      skillReadinessPct: 50,
+      nodesTotal: 4,
+      nodesCompleted: 3,
+      timelineWarning: null,
+    });
+    expect(result.streak_days).toBe(2);
+  });
+
+  it('should skip today when today has no completed nodes and count from yesterday', async () => {
+    prisma.user.findUnique.mockResolvedValue(
+      createUserRecord({
+        dailyActivity: [
+          { activityDate: new Date('2026-05-20T00:00:00Z'), nodesCompleted: 0 },
+          { activityDate: new Date('2026-05-19T00:00:00Z'), nodesCompleted: 2 },
+          { activityDate: new Date('2026-05-18T00:00:00Z'), nodesCompleted: 1 },
+          { activityDate: new Date('2026-05-17T00:00:00Z'), nodesCompleted: 0 },
+          { activityDate: new Date('2026-05-16T00:00:00Z'), nodesCompleted: 1 },
+        ],
+      }),
+    );
+
+    const result = await service.getDashboard(MOCK_USER_ID);
+
+    expect(result.streak_days).toBe(2);
+  });
+
+  it('should throw UserNotFoundException when user is missing', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(service.getDashboard(MOCK_USER_ID)).rejects.toThrow(UserNotFoundException);
+  });
+});


### PR DESCRIPTION
## Description

One-shot endpoint returning everything needed for the dashboard view: user profile, active roadmap progress summary, streak, and last 30 days activity (FR-14, FR-15, FR-16).

## Related Issue

Closes #45 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Add GET /api/v1/dashboard (one-shot summary) endpoint to the dashboard controller.
- Add getDashboardSummary(userId) service to aggregate data including profile, active roadmap progress, streak, and last 30 days of activity.
- Add/update DTOs and serializers for the response (DashboardSummaryDto, RoadmapProgressDto, ActivityPointDto, etc.).
- Use Prisma queries/aggregations to retrieve progress summaries and 30-day activity data.
- Add unit/integration tests for the endpoint (authentication and response shape validation).
- Handle errors and return appropriate HTTP status codes (401 for unauthorized access, 500 for server errors).

## How to Test

Steps to verify:

1. Run pnpm --filter api test -- test/unit/dashboard/dashboard.controller.spec.ts
2. Run pnpm --filter api test -- test/unit/dashboard/dashboard.service.spec.ts

Expected result: all tests pass.

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

