### PR TITLE
Feature/77 public template endpoints

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { OnboardingModule } from './modules/onboarding/onboarding.module';
 import { PrismaModule } from './modules/prisma/prisma.module';
 import { RoadmapsModule } from './modules/roadmaps/roadmaps.module';
+import { TemplatesModule } from './modules/templates/templates.module';
 import { UserModule } from './modules/user/user.module';
 
 @Module({
@@ -24,6 +25,7 @@ import { UserModule } from './modules/user/user.module';
     UserModule,
     OnboardingModule,
     RoadmapsModule,
+    TemplatesModule,
     DashboardModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/modules/templates/dto/list-templates-query.dto.ts
+++ b/apps/api/src/modules/templates/dto/list-templates-query.dto.ts
@@ -1,0 +1,26 @@
+import { RoleCategory } from '@repo/db/prisma/client';
+import { Transform, Type, type TransformFnParams } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+const toUppercaseString = ({ value }: TransformFnParams): unknown =>
+  typeof value === 'string' ? value.toUpperCase() : value;
+
+export class ListTemplatesQueryDto {
+  @IsOptional()
+  @Transform(toUppercaseString)
+  @IsEnum(RoleCategory)
+  roleCategory?: RoleCategory;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  perPage?: number = 20;
+}

--- a/apps/api/src/modules/templates/dto/template-node-response.dto.ts
+++ b/apps/api/src/modules/templates/dto/template-node-response.dto.ts
@@ -1,0 +1,18 @@
+import type { NodeType } from '@repo/db/prisma/client';
+
+export interface TemplateRoadmapNodeDto {
+  description: null | string;
+  estimatedHours: null | number;
+  id: string;
+  name: string;
+  nodeType: NodeType;
+  parentId: null | string;
+  posX: number;
+  posY: number;
+  roadmapId: string;
+  skillId: null | string;
+}
+
+export interface TemplateRoadmapNodesResponseDto {
+  nodes: TemplateRoadmapNodeDto[];
+}

--- a/apps/api/src/modules/templates/dto/template-nodes-filter.dto.ts
+++ b/apps/api/src/modules/templates/dto/template-nodes-filter.dto.ts
@@ -1,0 +1,13 @@
+import { NodeType } from '@repo/db/prisma/client';
+import { Transform, type TransformFnParams } from 'class-transformer';
+import { IsEnum, IsOptional } from 'class-validator';
+
+const toUppercaseString = ({ value }: TransformFnParams): unknown =>
+  typeof value === 'string' ? value.toUpperCase() : value;
+
+export class TemplateNodesFilterDto {
+  @IsOptional()
+  @Transform(toUppercaseString)
+  @IsEnum(NodeType)
+  nodeType?: NodeType;
+}

--- a/apps/api/src/modules/templates/templates.controller.ts
+++ b/apps/api/src/modules/templates/templates.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+
+import type {
+  PaginatedRoadmapsResponseDto,
+  RoadmapResponseDto,
+} from '@/modules/roadmaps/dto/roadmap-response.dto';
+
+import { Public } from '@/common/decorators/public.decorator';
+
+import type { TemplateRoadmapNodesResponseDto } from './dto/template-node-response.dto';
+
+import { ListTemplatesQueryDto } from './dto/list-templates-query.dto';
+import { TemplateNodesFilterDto } from './dto/template-nodes-filter.dto';
+import { TemplatesService } from './templates.service';
+
+@Controller('templates')
+export class TemplatesController {
+  constructor(private readonly templatesService: TemplatesService) {}
+
+  @Public()
+  @Get()
+  async listTemplates(
+    @Query() query: ListTemplatesQueryDto,
+  ): Promise<PaginatedRoadmapsResponseDto> {
+    return this.templatesService.listTemplates(query);
+  }
+
+  @Public()
+  @Get(':templateId/nodes')
+  async listTemplateNodes(
+    @Param('templateId') templateId: string,
+    @Query() query: TemplateNodesFilterDto,
+  ): Promise<TemplateRoadmapNodesResponseDto> {
+    return this.templatesService.listTemplateNodes(templateId, query);
+  }
+
+  @Public()
+  @Get(':templateId')
+  async getTemplate(@Param('templateId') templateId: string): Promise<RoadmapResponseDto> {
+    return this.templatesService.getTemplate(templateId);
+  }
+}

--- a/apps/api/src/modules/templates/templates.module.ts
+++ b/apps/api/src/modules/templates/templates.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../prisma/prisma.module';
+import { TemplatesController } from './templates.controller';
+import { TemplatesService } from './templates.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TemplatesController],
+  providers: [TemplatesService],
+  exports: [TemplatesService],
+})
+export class TemplatesModule {}

--- a/apps/api/src/modules/templates/templates.service.ts
+++ b/apps/api/src/modules/templates/templates.service.ts
@@ -1,0 +1,203 @@
+import { Injectable } from '@nestjs/common';
+import { type NodeType, type Prisma, type Roadmap } from '@repo/db/prisma/client';
+
+import type {
+  PaginatedRoadmapsResponseDto,
+  RoadmapResponseDto,
+} from '@/modules/roadmaps/dto/roadmap-response.dto';
+
+import { RoadmapNotFoundException } from '@/common/exceptions/app.exceptions';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+
+import type { ListTemplatesQueryDto } from './dto/list-templates-query.dto';
+import type {
+  TemplateRoadmapNodeDto,
+  TemplateRoadmapNodesResponseDto,
+} from './dto/template-node-response.dto';
+import type { TemplateNodesFilterDto } from './dto/template-nodes-filter.dto';
+
+const ROADMAP_SELECT = {
+  deadlineDate: true,
+  description: true,
+  estimatedWeeks: true,
+  generatedAt: true,
+  goalName: true,
+  hoursPerDay: true,
+  id: true,
+  isTemplate: true,
+  roleCategory: true,
+  title: true,
+  updatedAt: true,
+  userId: true,
+} satisfies Prisma.RoadmapSelect;
+
+const TEMPLATE_NODE_SELECT = {
+  description: true,
+  estimatedHours: true,
+  id: true,
+  name: true,
+  nodeType: true,
+  parentId: true,
+  posX: true,
+  posY: true,
+  roadmapId: true,
+  skillId: true,
+} satisfies Prisma.RoadmapNodeSelect;
+
+type SelectedRoadmap = Pick<Roadmap, keyof typeof ROADMAP_SELECT>;
+
+type DecimalLike = {
+  toNumber?: () => number;
+  toString: () => string;
+};
+
+type SelectedTemplateNode = {
+  description: string | null;
+  estimatedHours: Prisma.Decimal | number | null;
+  id: string;
+  name: string;
+  nodeType: NodeType;
+  parentId: string | null;
+  posX: Prisma.Decimal | number;
+  posY: Prisma.Decimal | number;
+  roadmapId: string;
+  skillId: string | null;
+};
+
+@Injectable()
+export class TemplatesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listTemplates(query: ListTemplatesQueryDto): Promise<PaginatedRoadmapsResponseDto> {
+    const page = query.page ?? 1;
+    const perPage = query.perPage ?? 20;
+    const skip = (page - 1) * perPage;
+    const where: Prisma.RoadmapWhereInput = {
+      isTemplate: true,
+    };
+
+    if (query.roleCategory) {
+      where.roleCategory = query.roleCategory;
+    }
+
+    const [templates, total] = await this.prisma.$transaction([
+      this.prisma.roadmap.findMany({
+        orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
+        select: ROADMAP_SELECT,
+        skip,
+        take: perPage,
+        where,
+      }),
+      this.prisma.roadmap.count({ where }),
+    ]);
+
+    return {
+      data: templates.map((template) => this.formatRoadmap(template)),
+      meta: {
+        page,
+        perPage,
+        total,
+        totalPages: Math.ceil(total / perPage),
+      },
+    };
+  }
+
+  async getTemplate(templateId: string): Promise<RoadmapResponseDto> {
+    const template = await this.prisma.roadmap.findFirst({
+      select: ROADMAP_SELECT,
+      where: {
+        id: templateId,
+        isTemplate: true,
+      },
+    });
+
+    if (!template) {
+      throw new RoadmapNotFoundException(templateId);
+    }
+
+    return this.formatRoadmap(template);
+  }
+
+  async listTemplateNodes(
+    templateId: string,
+    query: TemplateNodesFilterDto,
+  ): Promise<TemplateRoadmapNodesResponseDto> {
+    await this.assertTemplateExists(templateId);
+
+    const where: Prisma.RoadmapNodeWhereInput = {
+      roadmapId: templateId,
+    };
+
+    if (query.nodeType) {
+      where.nodeType = query.nodeType;
+    }
+
+    const nodes = await this.prisma.roadmapNode.findMany({
+      orderBy: [{ posY: 'asc' }, { posX: 'asc' }, { id: 'asc' }],
+      select: TEMPLATE_NODE_SELECT,
+      where,
+    });
+
+    return {
+      nodes: nodes.map((node) => this.formatTemplateNode(node)),
+    };
+  }
+
+  private async assertTemplateExists(templateId: string): Promise<void> {
+    const template = await this.prisma.roadmap.findFirst({
+      select: { id: true },
+      where: {
+        id: templateId,
+        isTemplate: true,
+      },
+    });
+
+    if (!template) {
+      throw new RoadmapNotFoundException(templateId);
+    }
+  }
+
+  private formatRoadmap(roadmap: SelectedRoadmap): RoadmapResponseDto {
+    return {
+      deadlineDate: this.formatDateOnly(roadmap.deadlineDate),
+      description: roadmap.description,
+      estimatedWeeks: roadmap.estimatedWeeks,
+      generatedAt: roadmap.generatedAt.toISOString(),
+      goalName: roadmap.goalName,
+      hoursPerDay: this.formatDecimal(roadmap.hoursPerDay),
+      id: roadmap.id,
+      isTemplate: roadmap.isTemplate,
+      roleCategory: roadmap.roleCategory,
+      title: roadmap.title,
+      updatedAt: roadmap.updatedAt.toISOString(),
+      userId: roadmap.userId,
+    };
+  }
+
+  private formatTemplateNode(node: SelectedTemplateNode): TemplateRoadmapNodeDto {
+    return {
+      description: node.description,
+      estimatedHours: this.formatDecimal(node.estimatedHours),
+      id: node.id,
+      name: node.name,
+      nodeType: node.nodeType,
+      parentId: node.parentId,
+      posX: Number(node.posX),
+      posY: Number(node.posY),
+      roadmapId: node.roadmapId,
+      skillId: node.skillId,
+    };
+  }
+
+  private formatDateOnly(date: Date | null): null | string {
+    return date ? date.toISOString().slice(0, 10) : null;
+  }
+
+  private formatDecimal(value: DecimalLike | null): null | number {
+    if (!value) {
+      return null;
+    }
+
+    return typeof value.toNumber === 'function' ? value.toNumber() : Number(value.toString());
+  }
+}

--- a/apps/api/test/unit/templates/templates.controller.spec.ts
+++ b/apps/api/test/unit/templates/templates.controller.spec.ts
@@ -1,0 +1,179 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import 'reflect-metadata';
+
+import type { INestApplication } from '@nestjs/common';
+import type { TestingModule } from '@nestjs/testing';
+import type { App } from 'supertest/types';
+
+import { APP_GUARD } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { NodeType, RoleCategory } from '@repo/db/prisma/client';
+import request from 'supertest';
+
+import { IS_PUBLIC_KEY } from '@/common/decorators/public.decorator';
+import { JwtAuthGuard } from '@/modules/auth/guards/jwt-auth.guard';
+import { TemplatesController } from '@/modules/templates/templates.controller';
+import { TemplatesService } from '@/modules/templates/templates.service';
+
+describe('TemplatesController', () => {
+  let controller: TemplatesController;
+
+  const mockTemplatesService = {
+    getTemplate: jest.fn(),
+    listTemplateNodes: jest.fn(),
+    listTemplates: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TemplatesController],
+      providers: [
+        {
+          provide: TemplatesService,
+          useValue: mockTemplatesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<TemplatesController>(TemplatesController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should list public templates', async () => {
+    const response = {
+      data: [],
+      meta: {
+        page: 1,
+        perPage: 20,
+        total: 0,
+        totalPages: 0,
+      },
+    };
+
+    mockTemplatesService.listTemplates.mockResolvedValue(response);
+
+    const query = { roleCategory: RoleCategory.WEB_DEVELOPMENT };
+    const result = await controller.listTemplates(query);
+
+    expect(mockTemplatesService.listTemplates).toHaveBeenCalledWith(query);
+    expect(result).toEqual(response);
+  });
+
+  it('should get one public template', async () => {
+    const response = {
+      deadlineDate: null,
+      description: 'A backend template',
+      estimatedWeeks: 16,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      goalName: null,
+      hoursPerDay: null,
+      id: 'template-1',
+      isTemplate: true,
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      title: 'Backend Template',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      userId: null,
+    };
+
+    mockTemplatesService.getTemplate.mockResolvedValue(response);
+
+    const result = await controller.getTemplate('template-1');
+
+    expect(mockTemplatesService.getTemplate).toHaveBeenCalledWith('template-1');
+    expect(result).toEqual(response);
+  });
+
+  it('should list public template nodes', async () => {
+    const response = { nodes: [] };
+
+    mockTemplatesService.listTemplateNodes.mockResolvedValue(response);
+
+    const query = { nodeType: NodeType.REQUIRED };
+    const result = await controller.listTemplateNodes('template-1', query);
+
+    expect(mockTemplatesService.listTemplateNodes).toHaveBeenCalledWith('template-1', query);
+    expect(result).toEqual(response);
+  });
+
+  it('should mark all template endpoints as public', () => {
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, TemplatesController.prototype.listTemplates)).toBe(
+      true,
+    );
+    expect(Reflect.getMetadata(IS_PUBLIC_KEY, TemplatesController.prototype.getTemplate)).toBe(
+      true,
+    );
+    expect(
+      Reflect.getMetadata(IS_PUBLIC_KEY, TemplatesController.prototype.listTemplateNodes),
+    ).toBe(true);
+  });
+});
+
+describe('TemplatesController public access', () => {
+  let app: INestApplication<App>;
+
+  const response = {
+    data: [],
+    meta: {
+      page: 1,
+      perPage: 20,
+      total: 0,
+      totalPages: 0,
+    },
+  };
+
+  const template = {
+    deadlineDate: null,
+    description: 'A public template',
+    estimatedWeeks: 16,
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    goalName: null,
+    hoursPerDay: null,
+    id: 'template-1',
+    isTemplate: true,
+    roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    title: 'Backend Template',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    userId: null,
+  };
+
+  const mockTemplatesService = {
+    getTemplate: jest.fn().mockResolvedValue(template),
+    listTemplateNodes: jest.fn().mockResolvedValue({ nodes: [] }),
+    listTemplates: jest.fn().mockResolvedValue(response),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TemplatesController],
+      providers: [
+        {
+          provide: TemplatesService,
+          useValue: mockTemplatesService,
+        },
+        {
+          provide: APP_GUARD,
+          useClass: JwtAuthGuard,
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await app.close();
+  });
+
+  it('should allow unauthenticated requests to template routes', async () => {
+    await request(app.getHttpServer()).get('/templates').expect(200).expect(response);
+    await request(app.getHttpServer()).get('/templates/template-1').expect(200).expect(template);
+    await request(app.getHttpServer()).get('/templates/template-1/nodes').expect(200).expect({
+      nodes: [],
+    });
+  });
+});

--- a/apps/api/test/unit/templates/templates.service.spec.ts
+++ b/apps/api/test/unit/templates/templates.service.spec.ts
@@ -1,0 +1,382 @@
+import type { TestingModule } from '@nestjs/testing';
+
+import { Test } from '@nestjs/testing';
+import { NodeType, RoleCategory } from '@repo/db/prisma/client';
+
+import { RoadmapNotFoundException } from '@/common/exceptions/app.exceptions';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+import { TemplatesService } from '@/modules/templates/templates.service';
+
+type AsyncMock<TResult = unknown, TArgs extends unknown[] = unknown[]> = jest.Mock<
+  Promise<TResult>,
+  TArgs
+>;
+
+interface TemplatesPrismaMock {
+  $transaction: AsyncMock<unknown, [unknown]>;
+  roadmap: {
+    count: AsyncMock<number>;
+    findFirst: AsyncMock<Record<string, unknown> | null>;
+    findMany: AsyncMock<unknown[]>;
+  };
+  roadmapNode: {
+    findMany: AsyncMock<unknown[]>;
+  };
+}
+
+const createDecimal = (value: number) => ({
+  toNumber: () => value,
+  toString: () => value.toString(),
+});
+
+const expectObjectContaining = <T extends object>(value: T): T =>
+  expect.objectContaining(value) as T;
+
+const createPrismaMock = (): TemplatesPrismaMock => ({
+  $transaction: jest.fn<Promise<unknown>, [unknown]>().mockImplementation(async (input) => {
+    if (Array.isArray(input)) {
+      return Promise.all(input as Promise<unknown>[]);
+    }
+
+    return input;
+  }),
+  roadmap: {
+    count: jest.fn<Promise<number>, unknown[]>(),
+    findFirst: jest.fn<Promise<Record<string, unknown> | null>, unknown[]>(),
+    findMany: jest.fn<Promise<unknown[]>, unknown[]>(),
+  },
+  roadmapNode: {
+    findMany: jest.fn<Promise<unknown[]>, unknown[]>(),
+  },
+});
+
+describe('TemplatesService', () => {
+  let service: TemplatesService;
+  let prisma: TemplatesPrismaMock;
+
+  beforeEach(async () => {
+    prisma = createPrismaMock();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TemplatesService,
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TemplatesService>(TemplatesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listTemplates', () => {
+    it('should return paginated templates with mapped response fields', async () => {
+      const template = {
+        deadlineDate: null,
+        description: 'A public backend learning plan',
+        estimatedWeeks: 16,
+        generatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        goalName: null,
+        hoursPerDay: null,
+        id: 'template-1',
+        isTemplate: true,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+        title: 'Backend Template',
+        updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+        userId: null,
+      };
+
+      prisma.roadmap.findMany.mockResolvedValue([template]);
+      prisma.roadmap.count.mockResolvedValue(21);
+
+      const result = await service.listTemplates({ page: 2, perPage: 10 });
+
+      expect(prisma.roadmap.findMany.mock.calls[0]?.[0]).toEqual({
+        orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
+        select: {
+          deadlineDate: true,
+          description: true,
+          estimatedWeeks: true,
+          generatedAt: true,
+          goalName: true,
+          hoursPerDay: true,
+          id: true,
+          isTemplate: true,
+          roleCategory: true,
+          title: true,
+          updatedAt: true,
+          userId: true,
+        },
+        skip: 10,
+        take: 10,
+        where: {
+          isTemplate: true,
+        },
+      });
+      expect(prisma.roadmap.count.mock.calls[0]?.[0]).toEqual({
+        where: {
+          isTemplate: true,
+        },
+      });
+      expect(result).toEqual({
+        data: [
+          {
+            deadlineDate: null,
+            description: 'A public backend learning plan',
+            estimatedWeeks: 16,
+            generatedAt: '2026-01-01T00:00:00.000Z',
+            goalName: null,
+            hoursPerDay: null,
+            id: 'template-1',
+            isTemplate: true,
+            roleCategory: RoleCategory.WEB_DEVELOPMENT,
+            title: 'Backend Template',
+            updatedAt: '2026-01-02T00:00:00.000Z',
+            userId: null,
+          },
+        ],
+        meta: {
+          page: 2,
+          perPage: 10,
+          total: 21,
+          totalPages: 3,
+        },
+      });
+    });
+
+    it('should apply roleCategory and default pagination', async () => {
+      prisma.roadmap.findMany.mockResolvedValue([]);
+      prisma.roadmap.count.mockResolvedValue(0);
+
+      const result = await service.listTemplates({
+        roleCategory: RoleCategory.DATA_ANALYSIS,
+      });
+
+      expect(prisma.roadmap.findMany.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({
+          skip: 0,
+          take: 20,
+          where: {
+            isTemplate: true,
+            roleCategory: RoleCategory.DATA_ANALYSIS,
+          },
+        }),
+      );
+      expect(prisma.roadmap.count.mock.calls[0]?.[0]).toEqual({
+        where: {
+          isTemplate: true,
+          roleCategory: RoleCategory.DATA_ANALYSIS,
+        },
+      });
+      expect(result.meta).toEqual({
+        page: 1,
+        perPage: 20,
+        total: 0,
+        totalPages: 0,
+      });
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('should return a formatted template roadmap', async () => {
+      const template = {
+        deadlineDate: null,
+        description: 'A frontend template',
+        estimatedWeeks: 12,
+        generatedAt: new Date('2026-01-03T00:00:00.000Z'),
+        goalName: null,
+        hoursPerDay: null,
+        id: 'template-1',
+        isTemplate: true,
+        roleCategory: RoleCategory.FRAMEWORKS,
+        title: 'React Template',
+        updatedAt: new Date('2026-01-04T00:00:00.000Z'),
+        userId: null,
+      };
+
+      prisma.roadmap.findFirst.mockResolvedValue(template);
+
+      const result = await service.getTemplate('template-1');
+
+      expect(prisma.roadmap.findFirst).toHaveBeenCalledWith({
+        select: expectObjectContaining({
+          id: true,
+          isTemplate: true,
+          title: true,
+        }),
+        where: {
+          id: 'template-1',
+          isTemplate: true,
+        },
+      });
+      expect(result).toEqual({
+        deadlineDate: null,
+        description: 'A frontend template',
+        estimatedWeeks: 12,
+        generatedAt: '2026-01-03T00:00:00.000Z',
+        goalName: null,
+        hoursPerDay: null,
+        id: 'template-1',
+        isTemplate: true,
+        roleCategory: RoleCategory.FRAMEWORKS,
+        title: 'React Template',
+        updatedAt: '2026-01-04T00:00:00.000Z',
+        userId: null,
+      });
+    });
+
+    it('should throw 404 when template is not found', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
+
+      await expect(service.getTemplate('template-1')).rejects.toThrow(RoadmapNotFoundException);
+    });
+
+    it('should throw 404 when the id belongs to a non-template roadmap', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
+
+      await expect(service.getTemplate('roadmap-1')).rejects.toThrow(RoadmapNotFoundException);
+      expect(prisma.roadmap.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: 'roadmap-1',
+            isTemplate: true,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('listTemplateNodes', () => {
+    it('should return flat template nodes without user progress', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue({ id: 'template-1' });
+      prisma.roadmapNode.findMany.mockResolvedValue([
+        {
+          description: null,
+          estimatedHours: null,
+          id: 'group-1',
+          name: 'Foundations',
+          nodeType: NodeType.GROUP,
+          parentId: null,
+          posX: createDecimal(100),
+          posY: createDecimal(200),
+          roadmapId: 'template-1',
+          skillId: null,
+        },
+        {
+          description: null,
+          estimatedHours: createDecimal(6),
+          id: 'node-1',
+          name: 'HTTP',
+          nodeType: NodeType.REQUIRED,
+          parentId: 'group-1',
+          posX: createDecimal(140),
+          posY: createDecimal(240),
+          roadmapId: 'template-1',
+          skillId: 'skill-1',
+        },
+      ]);
+
+      const result = await service.listTemplateNodes('template-1', {});
+
+      expect(prisma.roadmap.findFirst).toHaveBeenCalledWith({
+        select: { id: true },
+        where: {
+          id: 'template-1',
+          isTemplate: true,
+        },
+      });
+      expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith({
+        orderBy: [{ posY: 'asc' }, { posX: 'asc' }, { id: 'asc' }],
+        select: {
+          description: true,
+          estimatedHours: true,
+          id: true,
+          name: true,
+          nodeType: true,
+          parentId: true,
+          posX: true,
+          posY: true,
+          roadmapId: true,
+          skillId: true,
+        },
+        where: {
+          roadmapId: 'template-1',
+        },
+      });
+      expect(result).toEqual({
+        nodes: [
+          {
+            description: null,
+            estimatedHours: null,
+            id: 'group-1',
+            name: 'Foundations',
+            nodeType: NodeType.GROUP,
+            parentId: null,
+            posX: 100,
+            posY: 200,
+            roadmapId: 'template-1',
+            skillId: null,
+          },
+          {
+            description: null,
+            estimatedHours: 6,
+            id: 'node-1',
+            name: 'HTTP',
+            nodeType: NodeType.REQUIRED,
+            parentId: 'group-1',
+            posX: 140,
+            posY: 240,
+            roadmapId: 'template-1',
+            skillId: 'skill-1',
+          },
+        ],
+      });
+      expect(JSON.stringify(result)).not.toContain('progress');
+    });
+
+    it('should apply nodeType filtering', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue({ id: 'template-1' });
+      prisma.roadmapNode.findMany.mockResolvedValue([]);
+
+      await service.listTemplateNodes('template-1', { nodeType: NodeType.MILESTONE });
+
+      expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            nodeType: NodeType.MILESTONE,
+            roadmapId: 'template-1',
+          },
+        }),
+      );
+    });
+
+    it('should throw 404 when template is not found', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
+
+      await expect(service.listTemplateNodes('template-1', {})).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+      expect(prisma.roadmapNode.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should throw 404 when the id belongs to a non-template roadmap', async () => {
+      prisma.roadmap.findFirst.mockResolvedValue(null);
+
+      await expect(service.listTemplateNodes('roadmap-1', {})).rejects.toThrow(
+        RoadmapNotFoundException,
+      );
+      expect(prisma.roadmap.findFirst).toHaveBeenCalledWith({
+        select: { id: true },
+        where: {
+          id: 'roadmap-1',
+          isTemplate: true,
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Implements the public roadmap template endpoints documented in `docs/api_spec.md`.

## Related Issue

Closes #77

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added `TemplatesModule` with public template routes.
- Implemented `GET /templates` with pagination and `role_category` filtering.
- Implemented `GET /templates/:templateId`.
- Implemented `GET /templates/:templateId/nodes` with optional `nodeType` filtering.
- Ensured all template endpoints only return `isTemplate: true` roadmaps.
- Added tests for listing, detail, nodes, filtering, 404 behavior, and public access.

## How to Test

Steps to verify:

1. Run API tests:

   ```bash
   pnpm --filter api test
   ```

2. Build the API:

   ```bash
   pnpm --filter api build
   ```

3. Start the API and test public routes without auth:

   ```bash
   pnpm dev:api
   ```

   Then call:

   ```http
   GET http://localhost:3001/api/v1/templates
   GET http://localhost:3001/api/v1/templates/{templateId}
   GET http://localhost:3001/api/v1/templates/{templateId}/nodes
   ```

## Screenshots (if FE)

N/A

<details>
<summary><strong>Expand</strong></summary>

<!-- START - Add images here -->
<img width="1429" height="846" alt="image" src="https://github.com/user-attachments/assets/561a5c01-7570-4c8f-87eb-bfc713dbdd01" />
<img width="1430" height="845" alt="image" src="https://github.com/user-attachments/assets/d7c6c173-c9d8-4e1b-89d4-bfcdeb95f940" />
<img width="1429" height="834" alt="image" src="https://github.com/user-attachments/assets/04b6fb06-3ca3-4e8d-a96b-be81d054dfdb" />

<!-- END -->

</details>

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

Template routes are fully public via `@Public()` and intentionally exclude admin create/update/delete behavior. Non-template user roadmaps return `404` for detail/nodes and are excluded from list results.