### PR TITLE
Feature/79 user activity dashboard endpoints

### DIFF
--- a/apps/api/src/common/utils/streak-days.util.ts
+++ b/apps/api/src/common/utils/streak-days.util.ts
@@ -3,7 +3,14 @@ export interface StreakActivityRecord {
   nodesCompleted: number;
 }
 
-const toUtcDateKey = (date: Date): string => date.toISOString().slice(0, 10);
+export interface FilledDailyActivityEntry {
+  activityDate: string;
+  nodesCompleted: number;
+}
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export const toUtcDateKey = (date: Date): string => date.toISOString().slice(0, 10);
 
 const toUtcMidnightMs = (date: Date): number =>
   Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
@@ -34,3 +41,61 @@ export const calculateStreakDays = (
 
   return streakDays;
 };
+
+export const calculateLongestStreakDays = (dailyActivities: StreakActivityRecord[]): number => {
+  const activeDates = Array.from(
+    new Set(
+      dailyActivities
+        .filter((activity) => activity.nodesCompleted > 0)
+        .map((activity) => toUtcDateKey(activity.activityDate)),
+    ),
+  ).sort();
+
+  let longestStreak = 0;
+  let currentStreak = 0;
+  let previousDateMs: number | null = null;
+
+  activeDates.forEach((dateKey) => {
+    const currentDateMs = Date.parse(`${dateKey}T00:00:00.000Z`);
+
+    currentStreak =
+      previousDateMs !== null && currentDateMs - previousDateMs === MS_PER_DAY
+        ? currentStreak + 1
+        : 1;
+    longestStreak = Math.max(longestStreak, currentStreak);
+    previousDateMs = currentDateMs;
+  });
+
+  return longestStreak;
+};
+
+export const fillDailyActivityRange = (
+  dailyActivities: StreakActivityRecord[],
+  from: Date,
+  to: Date,
+): FilledDailyActivityEntry[] => {
+  const nodesCompletedByDate = new Map(
+    dailyActivities.map((activity) => [
+      toUtcDateKey(activity.activityDate),
+      activity.nodesCompleted,
+    ]),
+  );
+  const fromMidnightMs = toUtcMidnightMs(from);
+  const toMidnightMs = toUtcMidnightMs(to);
+  const days = Math.floor((toMidnightMs - fromMidnightMs) / MS_PER_DAY) + 1;
+
+  return Array.from({ length: days }, (_, index) => {
+    const date = new Date(fromMidnightMs + index * MS_PER_DAY);
+    const activityDate = toUtcDateKey(date);
+
+    return {
+      activityDate,
+      nodesCompleted: nodesCompletedByDate.get(activityDate) ?? 0,
+    };
+  });
+};
+
+export const subtractUtcDays = (date: Date, days: number): Date =>
+  new Date(toUtcMidnightMs(date) - days * MS_PER_DAY);
+
+export const toUtcMidnightDate = (date: Date): Date => new Date(toUtcMidnightMs(date));

--- a/apps/api/src/modules/dashboard/activity.controller.ts
+++ b/apps/api/src/modules/dashboard/activity.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Query } from '@nestjs/common';
+
+import type { ActivitySummaryResponse } from './types/dashboard-response.types';
+
+import { CurrentUser, type RequestUser } from '../auth/decorators/current-user.decorator';
+import { DashboardService } from './dashboard.service';
+import { ActivityQueryDto } from './dto/activity-query.dto';
+
+@Controller('users/me/activity')
+export class ActivityController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  async getMyActivity(
+    @CurrentUser() user: RequestUser,
+    @Query() query: ActivityQueryDto,
+  ): Promise<ActivitySummaryResponse> {
+    return this.dashboardService.getActivitySummary(user.id, query);
+  }
+}

--- a/apps/api/src/modules/dashboard/dashboard.module.ts
+++ b/apps/api/src/modules/dashboard/dashboard.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 
 import { PrismaModule } from '../prisma/prisma.module';
+import { ActivityController } from './activity.controller';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 
 @Module({
   imports: [PrismaModule],
-  controllers: [DashboardController],
+  controllers: [ActivityController, DashboardController],
   providers: [DashboardService],
 })
 export class DashboardModule {}

--- a/apps/api/src/modules/dashboard/dashboard.service.ts
+++ b/apps/api/src/modules/dashboard/dashboard.service.ts
@@ -1,13 +1,21 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { NodeStatus, NodeType, type Prisma, type UserRole } from '@repo/db/prisma/client';
 
 import type { TimelineWarningResponse } from '@/modules/roadmaps/types/roadmap-progress.types';
 
 import { UserNotFoundException } from '@/common/exceptions/app.exceptions';
-import { calculateStreakDays } from '@/common/utils/streak-days.util';
+import {
+  calculateLongestStreakDays,
+  calculateStreakDays,
+  fillDailyActivityRange,
+  subtractUtcDays,
+  toUtcMidnightDate,
+} from '@/common/utils/streak-days.util';
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
+import type { ActivityQueryDto } from './dto/activity-query.dto';
 import type {
+  ActivitySummaryResponse,
   DailyActivityEntryResponse,
   DashboardResponse,
 } from './types/dashboard-response.types';
@@ -43,6 +51,35 @@ const toNumberOrNull = (value: Prisma.Decimal | number | null) =>
 @Injectable()
 export class DashboardService {
   constructor(private readonly prisma: PrismaService) {}
+
+  async getActivitySummary(
+    userId: string,
+    query: ActivityQueryDto = {},
+  ): Promise<ActivitySummaryResponse> {
+    const { from, to } = this.resolveActivityRange(query);
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        dailyActivity: {
+          orderBy: [{ activityDate: 'desc' }, { id: 'asc' }],
+          select: {
+            activityDate: true,
+            nodesCompleted: true,
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      throw new UserNotFoundException(userId);
+    }
+
+    return {
+      streakDays: calculateStreakDays(user.dailyActivity),
+      longestStreak: calculateLongestStreakDays(user.dailyActivity),
+      activity: fillDailyActivityRange(user.dailyActivity, from, to),
+    };
+  }
 
   async getDashboard(userId: string): Promise<DashboardResponse> {
     const user = await this.prisma.user.findUnique({
@@ -94,23 +131,23 @@ export class DashboardService {
       : null;
 
     return {
-      user_profile: {
+      user: {
         id: user.id,
         email: user.email,
         fullName: user.fullName,
         role: this.formatRole(user.role),
         createdAt: user.createdAt.toISOString(),
       },
-      active_roadmap: activeRoadmap,
-      streak_days: streakDays,
-      activity_recent: this.formatRecentActivity(user.dailyActivity),
+      activeRoadmap,
+      streakDays,
+      activityRecent: this.formatRecentActivity(user.dailyActivity),
     };
   }
 
   private formatRoadmapProgressSummary(
     roadmap: DashboardRoadmapRecord,
     streakDays: number,
-  ): DashboardResponse['active_roadmap'] {
+  ): DashboardResponse['activeRoadmap'] {
     const nodesTotal = roadmap.nodes.length;
     const completedNodes = roadmap.nodes.filter((node) => this.isNodeCompleted(node));
     const nodesCompleted = completedNodes.length;
@@ -145,23 +182,10 @@ export class DashboardService {
     dailyActivities: DailyActivityRecord[],
     now = new Date(),
   ): DailyActivityEntryResponse[] {
-    const nodesCompletedByDate = new Map(
-      dailyActivities.map((activity) => [
-        this.toUtcDateKey(activity.activityDate),
-        activity.nodesCompleted,
-      ]),
-    );
-    const todayMidnightMs = this.toUtcMidnightMs(now);
+    const to = toUtcMidnightDate(now);
+    const from = subtractUtcDays(to, DASHBOARD_ACTIVITY_DAYS - 1);
 
-    return Array.from({ length: DASHBOARD_ACTIVITY_DAYS }, (_, index) => {
-      const date = new Date(todayMidnightMs - (DASHBOARD_ACTIVITY_DAYS - 1 - index) * MS_PER_DAY);
-      const dateKey = this.toUtcDateKey(date);
-
-      return {
-        activity_date: dateKey,
-        nodes_completed: nodesCompletedByDate.get(dateKey) ?? 0,
-      };
-    });
+    return fillDailyActivityRange(dailyActivities, from, to);
   }
 
   private calculateTimelineWarning(
@@ -221,8 +245,25 @@ export class DashboardService {
     return Math.round(value * 10) / 10;
   }
 
-  private toUtcDateKey(date: Date): string {
-    return date.toISOString().slice(0, 10);
+  private resolveActivityRange(query: ActivityQueryDto): { from: Date; to: Date } {
+    const to = query.to ? this.parseDateOnly(query.to) : toUtcMidnightDate(new Date());
+    const from = query.from ? this.parseDateOnly(query.from) : subtractUtcDays(to, 29);
+
+    if (from.getTime() > to.getTime()) {
+      throw new BadRequestException('Invalid activity date range');
+    }
+
+    return { from, to };
+  }
+
+  private parseDateOnly(value: string): Date {
+    const date = new Date(`${value}T00:00:00.000Z`);
+
+    if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+      throw new BadRequestException('Invalid activity date');
+    }
+
+    return date;
   }
 
   private toUtcMidnightMs(date: Date): number {

--- a/apps/api/src/modules/dashboard/dto/activity-query.dto.ts
+++ b/apps/api/src/modules/dashboard/dto/activity-query.dto.ts
@@ -1,0 +1,15 @@
+import { IsDateString, IsOptional, Matches } from 'class-validator';
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export class ActivityQueryDto {
+  @IsOptional()
+  @IsDateString()
+  @Matches(DATE_ONLY_PATTERN)
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @Matches(DATE_ONLY_PATTERN)
+  to?: string;
+}

--- a/apps/api/src/modules/dashboard/types/dashboard-response.types.ts
+++ b/apps/api/src/modules/dashboard/types/dashboard-response.types.ts
@@ -9,13 +9,19 @@ export interface DashboardUserProfileResponse {
 }
 
 export interface DailyActivityEntryResponse {
-  activity_date: string;
-  nodes_completed: number;
+  activityDate: string;
+  nodesCompleted: number;
+}
+
+export interface ActivitySummaryResponse {
+  streakDays: number;
+  longestStreak: number;
+  activity: DailyActivityEntryResponse[];
 }
 
 export interface DashboardResponse {
-  user_profile: DashboardUserProfileResponse;
-  active_roadmap: RoadmapProgressSummaryResponse | null;
-  streak_days: number;
-  activity_recent: DailyActivityEntryResponse[];
+  user: DashboardUserProfileResponse;
+  activeRoadmap: RoadmapProgressSummaryResponse | null;
+  streakDays: number;
+  activityRecent: DailyActivityEntryResponse[];
 }

--- a/apps/api/test/unit/dashboard/dashboard.controller.spec.ts
+++ b/apps/api/test/unit/dashboard/dashboard.controller.spec.ts
@@ -2,19 +2,22 @@ import type { TestingModule } from '@nestjs/testing';
 
 import { Test } from '@nestjs/testing';
 
+import { ActivityController } from '@/modules/dashboard/activity.controller';
 import { DashboardController } from '@/modules/dashboard/dashboard.controller';
 import { DashboardService } from '@/modules/dashboard/dashboard.service';
 
 describe('DashboardController', () => {
+  let activityController: ActivityController;
   let controller: DashboardController;
 
   const mockDashboardService = {
+    getActivitySummary: jest.fn(),
     getDashboard: jest.fn(),
   };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [DashboardController],
+      controllers: [ActivityController, DashboardController],
       providers: [
         {
           provide: DashboardService,
@@ -23,6 +26,7 @@ describe('DashboardController', () => {
       ],
     }).compile();
 
+    activityController = module.get<ActivityController>(ActivityController);
     controller = module.get<DashboardController>(DashboardController);
   });
 
@@ -39,16 +43,16 @@ describe('DashboardController', () => {
       createdAt: new Date('2026-01-01T00:00:00Z'),
     };
     const response = {
-      user_profile: {
+      user: {
         id: user.id,
         email: user.email,
         fullName: user.fullName,
         role: 'user',
         createdAt: user.createdAt.toISOString(),
       },
-      active_roadmap: null,
-      streak_days: 0,
-      activity_recent: [],
+      activeRoadmap: null,
+      streakDays: 0,
+      activityRecent: [],
     };
 
     mockDashboardService.getDashboard.mockResolvedValue(response);
@@ -56,6 +60,33 @@ describe('DashboardController', () => {
     const result = await controller.getDashboard(user);
 
     expect(mockDashboardService.getDashboard).toHaveBeenCalledWith('user-1');
+    expect(result).toEqual(response);
+  });
+
+  it('should call getActivitySummary and return response', async () => {
+    const user = {
+      id: 'user-1',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      role: 'USER',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    };
+    const query = { from: '2026-05-18', to: '2026-05-20' };
+    const response = {
+      streakDays: 2,
+      longestStreak: 4,
+      activity: [
+        { activityDate: '2026-05-18', nodesCompleted: 0 },
+        { activityDate: '2026-05-19', nodesCompleted: 1 },
+        { activityDate: '2026-05-20', nodesCompleted: 2 },
+      ],
+    };
+
+    mockDashboardService.getActivitySummary.mockResolvedValue(response);
+
+    const result = await activityController.getMyActivity(user, query);
+
+    expect(mockDashboardService.getActivitySummary).toHaveBeenCalledWith('user-1', query);
     expect(result).toEqual(response);
   });
 });

--- a/apps/api/test/unit/dashboard/dashboard.service.spec.ts
+++ b/apps/api/test/unit/dashboard/dashboard.service.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import type { NodeStatus, NodeType, UserRole } from '@repo/db/prisma/client';
 
+import { BadRequestException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { NodeStatus as NodeStatusValue, NodeType as NodeTypeValue } from '@repo/db/prisma/client';
 
@@ -116,7 +117,114 @@ describe('DashboardService', () => {
     );
   });
 
-  it('should return active_roadmap null when the user has no roadmap', async () => {
+  it('should query the current user activity payload', async () => {
+    prisma.user.findUnique.mockResolvedValue(createUserRecord());
+
+    await service.getActivitySummary(MOCK_USER_ID);
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: MOCK_USER_ID },
+      select: {
+        dailyActivity: {
+          orderBy: [{ activityDate: 'desc' }, { id: 'asc' }],
+          select: {
+            activityDate: true,
+            nodesCompleted: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('should return empty activity state with a zero-filled default range', async () => {
+    prisma.user.findUnique.mockResolvedValue(createUserRecord());
+
+    const result = await service.getActivitySummary(MOCK_USER_ID);
+
+    expect(result.streakDays).toBe(0);
+    expect(result.longestStreak).toBe(0);
+    expect(result.activity).toHaveLength(30);
+    expect(result.activity[0]).toEqual({
+      activityDate: '2026-04-21',
+      nodesCompleted: 0,
+    });
+    expect(result.activity[29]).toEqual({
+      activityDate: '2026-05-20',
+      nodesCompleted: 0,
+    });
+  });
+
+  it('should return populated activity with current and longest streaks', async () => {
+    prisma.user.findUnique.mockResolvedValue(
+      createUserRecord({
+        dailyActivity: [
+          { activityDate: new Date('2026-05-20T00:00:00Z'), nodesCompleted: 2 },
+          { activityDate: new Date('2026-05-19T00:00:00Z'), nodesCompleted: 1 },
+          { activityDate: new Date('2026-05-18T00:00:00Z'), nodesCompleted: 0 },
+          { activityDate: new Date('2026-05-16T00:00:00Z'), nodesCompleted: 1 },
+          { activityDate: new Date('2026-05-15T00:00:00Z'), nodesCompleted: 3 },
+          { activityDate: new Date('2026-05-14T00:00:00Z'), nodesCompleted: 1 },
+        ],
+      }),
+    );
+
+    const result = await service.getActivitySummary(MOCK_USER_ID, {
+      from: '2026-05-14',
+      to: '2026-05-20',
+    });
+
+    expect(result.streakDays).toBe(2);
+    expect(result.longestStreak).toBe(3);
+    expect(result.activity).toEqual([
+      { activityDate: '2026-05-14', nodesCompleted: 1 },
+      { activityDate: '2026-05-15', nodesCompleted: 3 },
+      { activityDate: '2026-05-16', nodesCompleted: 1 },
+      { activityDate: '2026-05-17', nodesCompleted: 0 },
+      { activityDate: '2026-05-18', nodesCompleted: 0 },
+      { activityDate: '2026-05-19', nodesCompleted: 1 },
+      { activityDate: '2026-05-20', nodesCompleted: 2 },
+    ]);
+  });
+
+  it('should default activity from date to 30 days before a custom to date', async () => {
+    prisma.user.findUnique.mockResolvedValue(createUserRecord());
+
+    const result = await service.getActivitySummary(MOCK_USER_ID, { to: '2026-05-10' });
+
+    expect(result.activity).toHaveLength(30);
+    expect(result.activity[0]?.activityDate).toBe('2026-04-11');
+    expect(result.activity[29]?.activityDate).toBe('2026-05-10');
+  });
+
+  it('should reject invalid activity ranges', async () => {
+    await expect(
+      service.getActivitySummary(MOCK_USER_ID, {
+        from: '2026-05-21',
+        to: '2026-05-20',
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('should reject invalid activity date values', async () => {
+    await expect(
+      service.getActivitySummary(MOCK_USER_ID, {
+        from: '2026-02-30',
+        to: '2026-05-20',
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('should throw UserNotFoundException when the activity user is missing', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(service.getActivitySummary(MOCK_USER_ID)).rejects.toThrow(UserNotFoundException);
+  });
+
+  it('should return activeRoadmap null when the user has no roadmap', async () => {
     prisma.user.findUnique.mockResolvedValue(
       createUserRecord({
         dailyActivity: [{ activityDate: new Date('2026-05-19T00:00:00Z'), nodesCompleted: 1 }],
@@ -125,16 +233,16 @@ describe('DashboardService', () => {
 
     const result = await service.getDashboard(MOCK_USER_ID);
 
-    expect(result.active_roadmap).toBeNull();
-    expect(result.streak_days).toBe(1);
-    expect(result.activity_recent).toHaveLength(30);
-    expect(result.activity_recent[0]).toEqual({
-      activity_date: '2026-04-21',
-      nodes_completed: 0,
+    expect(result.activeRoadmap).toBeNull();
+    expect(result.streakDays).toBe(1);
+    expect(result.activityRecent).toHaveLength(30);
+    expect(result.activityRecent[0]).toEqual({
+      activityDate: '2026-04-21',
+      nodesCompleted: 0,
     });
-    expect(result.activity_recent[29]).toEqual({
-      activity_date: '2026-05-20',
-      nodes_completed: 0,
+    expect(result.activityRecent[29]).toEqual({
+      activityDate: '2026-05-20',
+      nodesCompleted: 0,
     });
   });
 
@@ -184,7 +292,7 @@ describe('DashboardService', () => {
 
     const result = await service.getDashboard(MOCK_USER_ID);
 
-    expect(result.active_roadmap).toEqual({
+    expect(result.activeRoadmap).toEqual({
       roadmapId: 'roadmap-1',
       completionPct: 75,
       streakDays: 2,
@@ -193,7 +301,7 @@ describe('DashboardService', () => {
       nodesCompleted: 3,
       timelineWarning: null,
     });
-    expect(result.streak_days).toBe(2);
+    expect(result.streakDays).toBe(2);
   });
 
   it('should skip today when today has no completed nodes and count from yesterday', async () => {
@@ -211,7 +319,7 @@ describe('DashboardService', () => {
 
     const result = await service.getDashboard(MOCK_USER_ID);
 
-    expect(result.streak_days).toBe(2);
+    expect(result.streakDays).toBe(2);
   });
 
   it('should throw UserNotFoundException when user is missing', async () => {


### PR DESCRIPTION
## Description

Implements the learner activity and dashboard endpoints documented in `docs/api_spec.md`.

## Related Issue

Closes #79

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added authenticated `GET /users/me/activity`.
- Aligned `GET /dashboard` response fields with OpenAPI `camelCase` schemas.
- Added activity query DTO for optional `from` / `to` date filters.
- Added shared UTC activity helpers for filled date ranges and longest streak calculation.
- Added dashboard/activity controller and service test coverage.

## How to Test

Steps to verify:

1. Run `pnpm --filter api test -- dashboard`.
2. Run `pnpm --filter api test -- user`.
3. Run `pnpm --filter api build`.
4. Run `pnpm --filter api lint`.

## Screenshots (if FE)

N/A

<details>
<summary><strong>Expand</strong></summary>

<!-- START - Add images here -->

<!-- END -->

</details>

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

`pnpm --filter api check-types` is not available because the API package has no `check-types` script, so `pnpm --filter api build` was used for compile/type verification.