### PR TITLE
feat(web): enhance roadmap detail layout with dynamic metadata fetching

### DIFF
--- a/apps/web/app/(full-layout)/roadmaps/[id]/layout.tsx
+++ b/apps/web/app/(full-layout)/roadmaps/[id]/layout.tsx
@@ -1,9 +1,41 @@
 import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
+import { getRoadmapMetadataData } from '@/server-fetcher/roadmap-metadata-server';
+import { decodeReadableUrlId } from '@/utils/roadmap-url';
+
+const FALLBACK_METADATA: Metadata = {
   title: 'Roadmap Detail | RMap',
   description: 'View your roadmap details.',
 };
+
+interface RoadmapDetailMetadataProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export async function generateMetadata({ params }: RoadmapDetailMetadataProps): Promise<Metadata> {
+  const { id } = await params;
+
+  try {
+    const roadmapId = decodeReadableUrlId(id);
+    const roadmap = await getRoadmapMetadataData(roadmapId);
+    const title = roadmap?.title.trim();
+
+    if (!title) {
+      return FALLBACK_METADATA;
+    }
+
+    const description = roadmap?.description?.trim();
+
+    return {
+      title: `${title} | RMap`,
+      description: description || `View ${title} roadmap details.`,
+    };
+  } catch {
+    return FALLBACK_METADATA;
+  }
+}
 
 export default function RoadmapDetailLayout(props: LayoutProps<'/roadmaps/[id]'>) {
   return props.children;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,7 +7,7 @@ import '@repo/design-system/styles/globals.css';
 import '@xyflow/react/dist/style.css';
 
 import { AuthProvider } from '@/components/providers/auth-provider';
-import { authServerData } from '@/data/auth-server';
+import { authServerData } from '@/server-fetcher/auth-server';
 
 export const metadata: Metadata = {
   title: 'RMap',

--- a/apps/web/server-fetcher/auth-server.ts
+++ b/apps/web/server-fetcher/auth-server.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import { cookies } from 'next/headers';
 
 import { ENDPOINTS } from '@/constants/endpoints';

--- a/apps/web/server-fetcher/roadmap-metadata-server.ts
+++ b/apps/web/server-fetcher/roadmap-metadata-server.ts
@@ -1,0 +1,33 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+
+import type { RoadmapDetail } from '@/app/(full-layout)/roadmaps/[id]/_types/roadmap-detail.types';
+
+import { ENDPOINTS } from '@/constants/endpoints';
+import { fetchWrapper } from '@/lib/fetch-wrapper';
+
+export async function getRoadmapMetadataData(roadmapId: string): Promise<null | RoadmapDetail> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+
+  if (cookieHeader) {
+    try {
+      return await fetchWrapper<RoadmapDetail>(ENDPOINTS.roadmaps.getById(roadmapId), {
+        cache: 'no-store',
+        headers: {
+          Cookie: cookieHeader,
+        },
+      });
+    } catch {
+      // Fall back to public template metadata below.
+    }
+  }
+
+  try {
+    return await fetchWrapper<RoadmapDetail>(ENDPOINTS.templates.getById(roadmapId), {
+      cache: 'no-store',
+    });
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

Adds dynamic metadata for roadmap detail pages so the browser title and description reflect the selected roadmap/template title instead of always using static fallback metadata.

## Related Issue

Closes #

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added dynamic `generateMetadata` for `/roadmaps/[id]`.
- Fetches roadmap metadata server-side with fallback from authenticated roadmap to public template.
- Preserves fallback metadata when slug/data is invalid or unavailable.
- Renamed server fetch folder from `apps/web/data` to `apps/web/server-fetcher`.
- Moved server-only auth and roadmap metadata fetchers into `server-fetcher`.

## How to Test

Steps to verify:

1. Run `pnpm --filter web check-types`.
2. Run `pnpm --filter web lint`.
3. Open a roadmap detail page and verify the page title is `<Roadmap Title> | RMap`.
4. Open a public template roadmap page and verify the page title is `<Template Title> | RMap`.
5. Open an invalid/unavailable roadmap slug and verify the app falls back without breaking.

## Screenshots (if FE)

N/A, metadata-only change.

<details>
<summary><strong>Expand</strong></summary>

<!-- START - Add images here -->

<!-- END -->

</details>

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

Server-only fetch logic now lives under `apps/web/server-fetcher`. Metadata fetch is best-effort and intentionally falls back instead of redirecting or throwing.
