### PR TITLE
Feature/Move template list to a dedicated route

### DIFF
--- a/apps/web/app/(full-layout)/(home)/_components/hero-section.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/hero-section.tsx
@@ -12,10 +12,6 @@ import { HeroGradient } from '@/components/shared/hero-gradient';
 import { RainbowBar } from '@/components/shared/rainbow-bar';
 
 export function HeroSection() {
-  function handleScrollDown() {
-    window.scrollBy({ top: window.innerHeight, behavior: 'smooth' });
-  }
-
   return (
     <section className="relative min-h-svh overflow-hidden">
       <HeroGradient />
@@ -76,7 +72,11 @@ export function HeroSection() {
 
         {/* CTA Buttons */}
         <div className="flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
-          <Button size="lg" className="group/btn rounded-full" onClick={handleScrollDown}>
+          <Button
+            size="lg"
+            className="group/btn rounded-full"
+            render={<Link href={'/explore' as Route<string>} />}
+          >
             Explore available roadmaps
             <AnimatedIconSwap icon={ArrowRight} hoverIcon={ArrowRight02FreeIcons} />
           </Button>

--- a/apps/web/app/(full-layout)/(home)/_components/roadmap-featured-templates-loader.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/roadmap-featured-templates-loader.tsx
@@ -1,0 +1,155 @@
+import {
+  AnalyticsUpIcon,
+  ArrowUpRight01Icon,
+  Award01Icon,
+  BookHeartIcon,
+  BookUserIcon,
+  Calendar03Icon,
+  CalendarFavorite01Icon,
+} from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { cn } from '@repo/design-system/lib/utils';
+import Link from 'next/link';
+
+import type { RoadmapTemplate } from '@/app/(full-layout)/(home)/_types/landing';
+
+import { templateService } from '@/services/template.service';
+import { buildRoadmapHref } from '@/utils/roadmap-url';
+
+import { formatRoadmapTemplateCategory } from '../_utils/roadmap-templates';
+
+const FEATURED_TEMPLATE_COUNT = 8;
+const FEATURED_TEMPLATES_ERROR_MESSAGE = 'Unable to load featured roadmap templates.';
+const SOCIAL_PROOF_LABELS = [
+  { className: 'text-rose-500', icon: AnalyticsUpIcon, label: 'Trending now' },
+  { className: 'text-amber-500', icon: CalendarFavorite01Icon, label: 'Popular this week' },
+  { className: 'text-amber-500', icon: Calendar03Icon, label: 'Popular this month' },
+  { className: 'text-violet-500', icon: Award01Icon, label: 'Top pick' },
+  { className: 'text-pink-500', icon: BookHeartIcon, label: 'Learner favorite' },
+] as const;
+
+export async function RoadmapFeaturedTemplatesLoader() {
+  try {
+    const templates = await templateService.getRandomTemplates(FEATURED_TEMPLATE_COUNT);
+
+    if (!templates.length) {
+      return <RoadmapFeaturedTemplatesStatus message="No roadmap templates are available yet." />;
+    }
+
+    return (
+      <div className="flex w-full flex-col gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {templates.map((template) => (
+            <FeaturedRoadmapCard key={template.id} template={template} />
+          ))}
+          <SeeAllTemplatesLink />
+        </div>
+      </div>
+    );
+  } catch {
+    return <RoadmapFeaturedTemplatesStatus message={FEATURED_TEMPLATES_ERROR_MESSAGE} />;
+  }
+}
+
+function SeeAllTemplatesLink() {
+  return (
+    <Link
+      className="text-primary group/see-all focus-visible:ring-primary/30 flex min-h-38 w-full items-center justify-center gap-2 rounded-[10px] border border-dashed border-violet-500/20 bg-violet-500/[0.03] px-8 text-sm font-medium transition-all duration-200 hover:-translate-y-1 hover:border-violet-500/40 hover:bg-violet-500/10 hover:shadow-[0_18px_42px_rgba(76,29,149,0.12)] focus-visible:ring-2 focus-visible:outline-hidden"
+      href="/explore"
+    >
+      See All
+      <HugeiconsIcon
+        className="size-3.5 transition-transform duration-200 group-hover/see-all:translate-x-0.5 group-hover/see-all:-translate-y-0.5"
+        icon={ArrowUpRight01Icon}
+      />
+    </Link>
+  );
+}
+
+function FeaturedRoadmapCard({ template }: { template: RoadmapTemplate }) {
+  const description =
+    template.description?.trim() || 'Follow a structured path built from proven learning steps.';
+  const href = buildRoadmapHref({ id: template.id, title: template.title });
+  const category = formatRoadmapTemplateCategory(template.roleCategory);
+  const socialProof = getTemplateSocialProof(template);
+
+  return (
+    <Link
+      className="group/card border-border/70 bg-background/75 focus-visible:ring-primary/30 relative flex min-h-38 flex-col justify-between overflow-hidden rounded-xl border p-4 shadow-sm backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:border-violet-500/30 hover:bg-white/85 hover:shadow-[0_18px_42px_rgba(76,29,149,0.12)] focus-visible:ring-2 focus-visible:outline-hidden"
+      href={href as never}
+    >
+      <div
+        className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover/card:opacity-100"
+        style={{
+          backgroundImage:
+            'linear-gradient(135deg, rgba(124,58,237,0.08), rgba(236,72,153,0.04) 48%, rgba(14,165,233,0.06))',
+        }}
+        aria-hidden="true"
+      />
+      <div className="relative z-10 flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <span className="text-primary max-w-[calc(100%-2.5rem)] truncate rounded-full border border-violet-500/15 bg-violet-500/[0.06] px-2.5 py-1 text-[11px] font-semibold">
+            {category}
+          </span>
+          <span className="border-border/70 bg-background/80 text-muted-foreground group-hover/card:text-primary flex size-8 shrink-0 items-center justify-center rounded-full border transition-all duration-300 group-hover/card:translate-x-0.5 group-hover/card:-translate-y-0.5 group-hover/card:border-violet-500/25 group-hover/card:bg-violet-500/10">
+            <HugeiconsIcon className="size-3.5" icon={ArrowUpRight01Icon} />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h4 className="text-foreground line-clamp-2 text-base leading-6 font-semibold">
+            {template.title}
+          </h4>
+          <p className="text-muted-foreground line-clamp-2 text-sm leading-5">{description}</p>
+        </div>
+      </div>
+
+      <div className="relative z-10 mt-4 flex items-center justify-between gap-3">
+        <span className={cn('flex min-w-0 items-center gap-1.5 text-xs', socialProof.className)}>
+          <HugeiconsIcon className="size-3.5 shrink-0" icon={socialProof.icon} />
+          <span className="truncate">{socialProof.label}</span>
+        </span>
+        <span className="bg-primary/60 h-px flex-1 opacity-0 transition-opacity duration-300 group-hover/card:opacity-100" />
+      </div>
+    </Link>
+  );
+}
+
+function getTemplateSocialProof(template: RoadmapTemplate) {
+  const seed = hashTemplateKey(`${template.id}:${template.title}`);
+
+  if (seed % 3 === 0) {
+    return {
+      className: 'text-emerald-500',
+      icon: BookUserIcon,
+      label: `${(seed % 951) + 50} learners`,
+    };
+  }
+
+  return (
+    SOCIAL_PROOF_LABELS[seed % SOCIAL_PROOF_LABELS.length] ?? {
+      className: 'text-rose-500',
+      icon: AnalyticsUpIcon,
+      label: 'Trending now',
+    }
+  );
+}
+
+function hashTemplateKey(value: string): number {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash;
+}
+
+function RoadmapFeaturedTemplatesStatus({ message }: { message: string }) {
+  return (
+    <div className="border-border/70 bg-background/65 flex w-full flex-col items-center gap-4 rounded-2xl border px-4 py-12 text-center shadow-sm backdrop-blur-md">
+      <p className="text-muted-foreground text-sm">{message}</p>
+      <SeeAllTemplatesLink />
+    </div>
+  );
+}

--- a/apps/web/app/(full-layout)/(home)/_components/roadmap-featured-templates-loader.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/roadmap-featured-templates-loader.tsx
@@ -1,10 +1,7 @@
 import {
-  AnalyticsUpIcon,
   ArrowUpRight01Icon,
   Award01Icon,
   BookHeartIcon,
-  BookUserIcon,
-  Calendar03Icon,
   CalendarFavorite01Icon,
 } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
@@ -20,12 +17,10 @@ import { formatRoadmapTemplateCategory } from '../_utils/roadmap-templates';
 
 const FEATURED_TEMPLATE_COUNT = 8;
 const FEATURED_TEMPLATES_ERROR_MESSAGE = 'Unable to load featured roadmap templates.';
-const SOCIAL_PROOF_LABELS = [
-  { className: 'text-rose-500', icon: AnalyticsUpIcon, label: 'Trending now' },
-  { className: 'text-amber-500', icon: CalendarFavorite01Icon, label: 'Popular this week' },
-  { className: 'text-amber-500', icon: Calendar03Icon, label: 'Popular this month' },
-  { className: 'text-violet-500', icon: Award01Icon, label: 'Top pick' },
-  { className: 'text-pink-500', icon: BookHeartIcon, label: 'Learner favorite' },
+const FEATURED_TEMPLATE_BADGES = [
+  { className: 'text-featured-template-choice', icon: Award01Icon, label: "Developers' Choice" },
+  { className: 'text-featured-template-featured', icon: CalendarFavorite01Icon, label: 'Featured' },
+  { className: 'text-featured-template-recommended', icon: BookHeartIcon, label: 'Recommended' },
 ] as const;
 
 export async function RoadmapFeaturedTemplatesLoader() {
@@ -54,7 +49,7 @@ export async function RoadmapFeaturedTemplatesLoader() {
 function SeeAllTemplatesLink() {
   return (
     <Link
-      className="text-primary group/see-all focus-visible:ring-primary/30 flex min-h-38 w-full items-center justify-center gap-2 rounded-[10px] border border-dashed border-violet-500/20 bg-violet-500/[0.03] px-8 text-sm font-medium transition-all duration-200 hover:-translate-y-1 hover:border-violet-500/40 hover:bg-violet-500/10 hover:shadow-[0_18px_42px_rgba(76,29,149,0.12)] focus-visible:ring-2 focus-visible:outline-hidden"
+      className="text-primary group/see-all focus-visible:ring-primary/30 border-primary/20 bg-primary/3 hover:border-primary/40 hover:bg-primary/10 flex min-h-38 w-full items-center justify-center gap-2 rounded-[10px] border border-dashed px-8 text-sm font-medium transition-all duration-200 hover:-translate-y-1 hover:shadow-(--shadow-featured-template-card) focus-visible:ring-2 focus-visible:outline-hidden"
       href="/explore"
     >
       See All
@@ -71,27 +66,24 @@ function FeaturedRoadmapCard({ template }: { template: RoadmapTemplate }) {
     template.description?.trim() || 'Follow a structured path built from proven learning steps.';
   const href = buildRoadmapHref({ id: template.id, title: template.title });
   const category = formatRoadmapTemplateCategory(template.roleCategory);
-  const socialProof = getTemplateSocialProof(template);
+  const badge = getFeaturedTemplateBadge(template);
 
   return (
     <Link
-      className="group/card border-border/70 bg-background/75 focus-visible:ring-primary/30 relative flex min-h-38 flex-col justify-between overflow-hidden rounded-xl border p-4 shadow-sm backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:border-violet-500/30 hover:bg-white/85 hover:shadow-[0_18px_42px_rgba(76,29,149,0.12)] focus-visible:ring-2 focus-visible:outline-hidden"
+      className="group/card border-border/70 bg-background/75 focus-visible:ring-primary/30 hover:border-primary/30 hover:bg-card/85 relative flex min-h-38 flex-col justify-between overflow-hidden rounded-xl border p-4 shadow-sm backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-(--shadow-featured-template-card) focus-visible:ring-2 focus-visible:outline-hidden"
       href={href as never}
     >
       <div
         className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover/card:opacity-100"
-        style={{
-          backgroundImage:
-            'linear-gradient(135deg, rgba(124,58,237,0.08), rgba(236,72,153,0.04) 48%, rgba(14,165,233,0.06))',
-        }}
+        style={{ backgroundImage: 'var(--gradient-featured-template-card)' }}
         aria-hidden="true"
       />
       <div className="relative z-10 flex flex-col gap-3">
         <div className="flex items-start justify-between gap-3">
-          <span className="text-primary max-w-[calc(100%-2.5rem)] truncate rounded-full border border-violet-500/15 bg-violet-500/[0.06] px-2.5 py-1 text-[11px] font-semibold">
+          <span className="text-primary border-primary/15 bg-primary/6 max-w-[calc(100%-2.5rem)] truncate rounded-full border px-2.5 py-1 text-[11px] font-semibold">
             {category}
           </span>
-          <span className="border-border/70 bg-background/80 text-muted-foreground group-hover/card:text-primary flex size-8 shrink-0 items-center justify-center rounded-full border transition-all duration-300 group-hover/card:translate-x-0.5 group-hover/card:-translate-y-0.5 group-hover/card:border-violet-500/25 group-hover/card:bg-violet-500/10">
+          <span className="border-border/70 bg-background/80 text-muted-foreground group-hover/card:text-primary group-hover/card:border-primary/25 group-hover/card:bg-primary/10 flex size-8 shrink-0 items-center justify-center rounded-full border transition-all duration-300 group-hover/card:translate-x-0.5 group-hover/card:-translate-y-0.5">
             <HugeiconsIcon className="size-3.5" icon={ArrowUpRight01Icon} />
           </span>
         </div>
@@ -105,9 +97,9 @@ function FeaturedRoadmapCard({ template }: { template: RoadmapTemplate }) {
       </div>
 
       <div className="relative z-10 mt-4 flex items-center justify-between gap-3">
-        <span className={cn('flex min-w-0 items-center gap-1.5 text-xs', socialProof.className)}>
-          <HugeiconsIcon className="size-3.5 shrink-0" icon={socialProof.icon} />
-          <span className="truncate">{socialProof.label}</span>
+        <span className={cn('flex min-w-0 items-center gap-1.5 text-xs', badge.className)}>
+          <HugeiconsIcon className="size-3.5 shrink-0" icon={badge.icon} />
+          <span className="truncate">{badge.label}</span>
         </span>
         <span className="bg-primary/60 h-px flex-1 opacity-0 transition-opacity duration-300 group-hover/card:opacity-100" />
       </div>
@@ -115,22 +107,14 @@ function FeaturedRoadmapCard({ template }: { template: RoadmapTemplate }) {
   );
 }
 
-function getTemplateSocialProof(template: RoadmapTemplate) {
+function getFeaturedTemplateBadge(template: RoadmapTemplate) {
   const seed = hashTemplateKey(`${template.id}:${template.title}`);
 
-  if (seed % 3 === 0) {
-    return {
-      className: 'text-emerald-500',
-      icon: BookUserIcon,
-      label: `${(seed % 951) + 50} learners`,
-    };
-  }
-
   return (
-    SOCIAL_PROOF_LABELS[seed % SOCIAL_PROOF_LABELS.length] ?? {
-      className: 'text-rose-500',
-      icon: AnalyticsUpIcon,
-      label: 'Trending now',
+    FEATURED_TEMPLATE_BADGES[seed % FEATURED_TEMPLATE_BADGES.length] ?? {
+      className: 'text-featured-template-choice',
+      icon: Award01Icon,
+      label: "Developers' Choice",
     }
   );
 }

--- a/apps/web/app/(full-layout)/(home)/_components/roadmap-featured-templates-skeleton.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/roadmap-featured-templates-skeleton.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '@repo/design-system/components/ui/skeleton';
+
+export function RoadmapFeaturedTemplatesSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 9 }, (_, index) => (
+          <Skeleton key={index} className="h-38 rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(full-layout)/(home)/_components/roadmap-section.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/roadmap-section.tsx
@@ -5,8 +5,8 @@ import { Suspense } from 'react';
 import { MaskBackground } from '@/components/shared/mask-background';
 import { RainbowBar } from '@/components/shared/rainbow-bar';
 
-import { RoadmapTemplatesLoader } from './roadmap-templates-loader';
-import { RoadmapTemplatesSkeleton } from './roadmap-templates-skeleton';
+import { RoadmapFeaturedTemplatesLoader } from './roadmap-featured-templates-loader';
+import { RoadmapFeaturedTemplatesSkeleton } from './roadmap-featured-templates-skeleton';
 
 export function RoadmapSection() {
   return (
@@ -53,8 +53,8 @@ export function RoadmapSection() {
           </div>
         </div>
 
-        <Suspense fallback={<RoadmapTemplatesSkeleton />}>
-          <RoadmapTemplatesLoader />
+        <Suspense fallback={<RoadmapFeaturedTemplatesSkeleton />}>
+          <RoadmapFeaturedTemplatesLoader />
         </Suspense>
       </SectionContainer>
     </section>

--- a/apps/web/app/(full-layout)/(home)/_components/ui/roadmap-grid.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/ui/roadmap-grid.tsx
@@ -1,14 +1,17 @@
+import { cn } from '@repo/design-system/lib/utils';
+
 import type { RoadmapItemData } from '@/app/(full-layout)/(home)/_types/landing';
 
 import { RoadmapItem } from './roadmap-item';
 
 interface RoadmapGridProps {
+  className?: string;
   items: RoadmapItemData[];
 }
 
-export function RoadmapGrid({ items }: RoadmapGridProps) {
+export function RoadmapGrid({ className, items }: RoadmapGridProps) {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    <div className={cn('grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3', className)}>
       {items.map((item) => (
         <RoadmapItem key={item.id ?? item.href ?? item.label} {...item} />
       ))}

--- a/apps/web/app/(full-layout)/(home)/_data/landing.ts
+++ b/apps/web/app/(full-layout)/(home)/_data/landing.ts
@@ -2,7 +2,7 @@ import type { NavItem, RoadmapTimelineItem } from '@/app/(full-layout)/(home)/_t
 
 export const NAV_ITEMS: NavItem[] = [
   { label: 'Explore', href: '/explore' },
-  { label: 'Generate roadmap', href: '/roadmaps/generate' },
+  { label: 'Generate personalized roadmap', href: '/roadmaps/generate' },
 ];
 
 export const TIMELINE_ITEMS: RoadmapTimelineItem[] = [

--- a/apps/web/app/(full-layout)/(home)/_data/landing.ts
+++ b/apps/web/app/(full-layout)/(home)/_data/landing.ts
@@ -3,7 +3,6 @@ import type { NavItem, RoadmapTimelineItem } from '@/app/(full-layout)/(home)/_t
 export const NAV_ITEMS: NavItem[] = [
   { label: 'Explore', href: '/explore' },
   { label: 'Generate roadmap', href: '/roadmaps/generate' },
-  { label: 'Dashboard', href: '/dashboard' },
 ];
 
 export const TIMELINE_ITEMS: RoadmapTimelineItem[] = [

--- a/apps/web/app/(full-layout)/(home)/_data/landing.ts
+++ b/apps/web/app/(full-layout)/(home)/_data/landing.ts
@@ -1,8 +1,9 @@
 import type { NavItem, RoadmapTimelineItem } from '@/app/(full-layout)/(home)/_types/landing';
 
 export const NAV_ITEMS: NavItem[] = [
+  { label: 'Explore', href: '/explore' },
+  { label: 'Generate roadmap', href: '/roadmaps/generate' },
   { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Generate personalized roadmap', href: '/roadmaps/generate' },
 ];
 
 export const TIMELINE_ITEMS: RoadmapTimelineItem[] = [

--- a/apps/web/app/(full-layout)/(home)/_utils/roadmap-templates.ts
+++ b/apps/web/app/(full-layout)/(home)/_utils/roadmap-templates.ts
@@ -10,6 +10,14 @@ const CATEGORY_COLLATOR = new Intl.Collator('en-US', {
   sensitivity: 'base',
 });
 
+export function mapRoadmapTemplateToItem(template: RoadmapTemplate): RoadmapItemData {
+  return {
+    href: buildRoadmapHref({ id: template.id, title: template.title }),
+    id: template.id,
+    label: template.title,
+  };
+}
+
 export function formatRoadmapTemplateCategory(category: string): string {
   return category
     .split('_')
@@ -24,11 +32,7 @@ export function groupRoadmapTemplates(templates: RoadmapTemplate[]): RoadmapTemp
   templates.forEach((template) => {
     const categoryItems = itemsByCategory.get(template.roleCategory) ?? [];
 
-    categoryItems.push({
-      href: buildRoadmapHref({ id: template.id, title: template.title }),
-      id: template.id,
-      label: template.title,
-    });
+    categoryItems.push(mapRoadmapTemplateToItem(template));
 
     itemsByCategory.set(template.roleCategory, categoryItems);
   });

--- a/apps/web/app/(full-layout)/dashboard/_components/dashboard-overall-progress.tsx
+++ b/apps/web/app/(full-layout)/dashboard/_components/dashboard-overall-progress.tsx
@@ -88,7 +88,7 @@ export function DashboardOverallProgress({ summary }: DashboardOverallProgressPr
           <HugeiconsIcon className="text-primary size-5" icon={Target02Icon} />
         </CardAction>
       </CardHeader>
-      <CardContent className="grid flex-1 gap-5 pb-5 sm:grid-cols-[minmax(180px,0.9fr)_minmax(0,1fr)] sm:items-center xl:grid-cols-1 2xl:grid-cols-[minmax(180px,0.9fr)_minmax(0,1fr)]">
+      <CardContent className="grid flex-1 gap-5 pb-5 sm:grid-cols-[minmax(180px,0.9fr)_minmax(0,1fr)] sm:items-center xl:grid-cols-1 xl:grid-cols-[minmax(180px,0.9fr)_minmax(0,1fr)]">
         <div className="relative mx-auto size-48">
           <svg className="size-full -rotate-90" role="img" viewBox="0 0 160 160">
             <circle

--- a/apps/web/app/(full-layout)/explore/page.tsx
+++ b/apps/web/app/(full-layout)/explore/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next';
+
+import { SectionContainer } from '@repo/design-system/components/common/section-container';
+import { Suspense } from 'react';
+
+import { HeroGradient } from '@/components/shared/hero-gradient';
+import { MaskBackground } from '@/components/shared/mask-background';
+import { RainbowBar } from '@/components/shared/rainbow-bar';
+
+import { RoadmapTemplatesLoader } from '../(home)/_components/roadmap-templates-loader';
+import { RoadmapTemplatesSkeleton } from '../(home)/_components/roadmap-templates-skeleton';
+
+export const metadata: Metadata = {
+  title: 'Explore Roadmaps | RMap',
+  description: 'Browse role-based and skill-based roadmap templates for your learning journey.',
+};
+
+export default function ExploreRoadmapsPage() {
+  return (
+    <main className="relative flex min-h-screen flex-col items-center overflow-hidden bg-[linear-gradient(180deg,#eef7ff_0%,#f7f2ff_54%,#fff7fb_100%)] pt-32 pb-32">
+      <HeroGradient />
+      <RainbowBar />
+      <MaskBackground />
+
+      <SectionContainer className="relative z-10 flex flex-col items-center justify-center gap-12">
+        <div className="flex w-full max-w-180 flex-col items-center gap-5 text-center">
+          <h1 className="text-title">Explore Learning Roadmaps</h1>
+          <p className="text-subtitle">
+            Browse every roadmap template, filter by category, and find the path that matches your
+            next learning goal.
+          </p>
+        </div>
+
+        <Suspense fallback={<RoadmapTemplatesSkeleton />}>
+          <RoadmapTemplatesLoader />
+        </Suspense>
+      </SectionContainer>
+    </main>
+  );
+}

--- a/apps/web/services/template.service.ts
+++ b/apps/web/services/template.service.ts
@@ -32,6 +32,21 @@ async function listTemplatesPage(page: number): Promise<PaginatedTemplatesRespon
   });
 }
 
+function shuffleTemplates(templates: RoadmapTemplate[]): RoadmapTemplate[] {
+  const shuffledTemplates = [...templates];
+
+  for (let index = shuffledTemplates.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    const currentTemplate = shuffledTemplates[index] as RoadmapTemplate;
+    const randomTemplate = shuffledTemplates[randomIndex] as RoadmapTemplate;
+
+    shuffledTemplates[index] = randomTemplate;
+    shuffledTemplates[randomIndex] = currentTemplate;
+  }
+
+  return shuffledTemplates;
+}
+
 export const templateService = {
   getAllTemplates: async (): Promise<RoadmapTemplate[]> => {
     const firstPage = await listTemplatesPage(1);
@@ -43,5 +58,11 @@ export const templateService = {
     const remainingPages = await Promise.all(remainingPageNumbers.map(listTemplatesPage));
 
     return [firstPage, ...remainingPages].flatMap((page) => page.data);
+  },
+
+  getRandomTemplates: async (count: number): Promise<RoadmapTemplate[]> => {
+    const templates = await templateService.getAllTemplates();
+
+    return shuffleTemplates(templates).slice(0, count);
   },
 };

--- a/packages/design-system/styles/globals.css
+++ b/packages/design-system/styles/globals.css
@@ -67,6 +67,9 @@
   --color-gradient-cta-pill: var(--gradient-cta-pill);
   --color-gradient-search-bar: var(--gradient-search-bar);
   --color-gradient-category-pill: var(--gradient-category-pill);
+  --color-featured-template-choice: var(--featured-template-choice);
+  --color-featured-template-featured: var(--featured-template-featured);
+  --color-featured-template-recommended: var(--featured-template-recommended);
 
   --color-border-node: var(--border-node);
   --color-background-node-completed: var(--background-node-completed);
@@ -166,6 +169,16 @@
       hsla(228, 96%, 89%, 0.3) 100%
     ),
     linear-gradient(90deg, hsla(0, 0%, 100%, 0.75) 0%, hsla(0, 0%, 100%, 0.75) 100%);
+  --gradient-featured-template-card: linear-gradient(
+    135deg,
+    hsla(262, 83%, 58%, 0.08),
+    hsla(326, 79%, 60%, 0.04) 48%,
+    hsla(198, 88%, 54%, 0.06)
+  );
+  --shadow-featured-template-card: 0 18px 42px hsla(262, 70%, 32%, 0.12);
+  --featured-template-choice: var(--primary);
+  --featured-template-featured: hsl(198, 88%, 42%);
+  --featured-template-recommended: hsl(160, 84%, 33%);
 
   /* Roadmap */
   --border-node: #1b1b20;


### PR DESCRIPTION
## Description

Move the full template list out of / and into a separate route. Keep only featured templates on the home page.

## Related Issue

Closes #101
Closes #107

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- The home page highlight selected templates instead of carrying the full template browsing experience.
- Move the full template list out of / and into a separate route. Keep only featured templates on the home page.

## Screenshots (if FE)

<details>
<summary><strong>Expand</strong></summary>

<!-- START - Add images here -->
<img width="3042" height="5044" alt="localhost_3000_explore" src="https://github.com/user-attachments/assets/df547722-b7da-43e7-9498-1a8dfb14ff46" />
<img width="3037" height="1668" alt="image" src="https://github.com/user-attachments/assets/944d07ae-32d1-4299-99be-b04848f3965a" />

<!-- END -->

</details>

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed
