### PR TITLE
fix(auth): implement redirect handling for protected routes and sign-in flow

### DIFF
--- a/apps/web/app/(auth)/sign-in/page.tsx
+++ b/apps/web/app/(auth)/sign-in/page.tsx
@@ -17,6 +17,7 @@ import { useForm } from 'react-hook-form';
 import { PasswordInput } from '@/app/(auth)/_components/password-input';
 import { SocialAuthButtons } from '@/app/(auth)/_components/social-auth-buttons';
 import { useAuth } from '@/hooks/use-auth';
+import { consumeAuthRedirectPath } from '@/utils/auth-redirect';
 import { type SignInValues, signInSchema } from '@/validations/auth.schema';
 
 export default function SignInPage() {
@@ -38,7 +39,9 @@ export default function SignInPage() {
     try {
       await signIn(values);
       toast.success('Signed in successfully');
-      router.push('/');
+      const callbackUrl = new URLSearchParams(window.location.search).get('callbackUrl');
+      router.replace(consumeAuthRedirectPath(callbackUrl) as Route<string>);
+      router.refresh();
     } catch {
       toast.error('Sign in failed', {
         description: 'Please check your credentials and try again.',

--- a/apps/web/app/(auth)/sign-up/page.tsx
+++ b/apps/web/app/(auth)/sign-up/page.tsx
@@ -18,6 +18,7 @@ import { useForm } from 'react-hook-form';
 import { PasswordInput } from '@/app/(auth)/_components/password-input';
 import { SocialAuthButtons } from '@/app/(auth)/_components/social-auth-buttons';
 import { useAuth } from '@/hooks/use-auth';
+import { consumeAuthRedirectPath } from '@/utils/auth-redirect';
 import { type SignUpValues, signUpSchema } from '@/validations/auth.schema';
 
 export default function SignUpPage() {
@@ -50,7 +51,9 @@ export default function SignUpPage() {
     try {
       await signUp(values);
       toast.success('Account created successfully');
-      router.push('/');
+      const callbackUrl = new URLSearchParams(window.location.search).get('callbackUrl');
+      router.replace(consumeAuthRedirectPath(callbackUrl) as Route<string>);
+      router.refresh();
     } catch {
       toast.error('Sign up failed', {
         description: 'Email may already exist or request is invalid.',

--- a/apps/web/app/(full-layout)/(home)/_components/hero-section.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/hero-section.tsx
@@ -6,9 +6,9 @@ import { ArrowRight, ArrowRight02FreeIcons } from '@hugeicons/core-free-icons';
 import { AnimatedIconSwap } from '@repo/design-system/components/common/animated-icon-swap';
 import { Button } from '@repo/design-system/components/ui/button';
 import Image from 'next/image';
-import Link from 'next/link';
 
 import { HeroGradient } from '@/components/shared/hero-gradient';
+import { ProtectedLink } from '@/components/shared/protected-link';
 import { RainbowBar } from '@/components/shared/rainbow-bar';
 
 export function HeroSection() {
@@ -81,7 +81,9 @@ export function HeroSection() {
             <AnimatedIconSwap icon={ArrowRight} hoverIcon={ArrowRight02FreeIcons} />
           </Button>
           <Button variant="outline" size="lg" className="group/btn rounded-full">
-            <Link href={'/roadmaps/generate' as Route<string>}>Create your roadmap</Link>
+            <ProtectedLink href={'/roadmaps/generate' as Route<string>}>
+              Create your roadmap
+            </ProtectedLink>
             <AnimatedIconSwap icon={ArrowRight} hoverIcon={ArrowRight02FreeIcons} />
           </Button>
         </div>

--- a/apps/web/app/(full-layout)/(home)/_components/personalized-section.tsx
+++ b/apps/web/app/(full-layout)/(home)/_components/personalized-section.tsx
@@ -13,6 +13,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { MaskBackground } from '@/components/shared/mask-background';
+import { ProtectedLink } from '@/components/shared/protected-link';
 import { RainbowBar } from '@/components/shared/rainbow-bar';
 
 const NOTEBOOK_ITEMS = [
@@ -60,7 +61,7 @@ export function PersonalizedSection() {
             <Button
               size="lg"
               className="group/btn rounded-full"
-              render={<Link href={'/roadmaps/generate' as never} />}
+              render={<ProtectedLink href={'/roadmaps/generate' as never} />}
             >
               Try now
               <AnimatedIconSwap icon={ArrowRight} hoverIcon={ArrowRight02FreeIcons} />

--- a/apps/web/components/layouts/header.tsx
+++ b/apps/web/components/layouts/header.tsx
@@ -23,6 +23,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { NAV_ITEMS } from '@/app/(full-layout)/(home)/_data/landing';
+import { ProtectedLink } from '@/components/shared/protected-link';
 import { useAuth } from '@/hooks/use-auth';
 
 export function Header() {
@@ -63,7 +64,9 @@ export function Header() {
             {NAV_ITEMS.map((item) => (
               <NavigationMenuItem key={item.href} className="group relative">
                 <NavigationMenuLink
-                  render={<Link href={item.href as Route<string>}>{item.label}</Link>}
+                  render={
+                    <ProtectedLink href={item.href as Route<string>}>{item.label}</ProtectedLink>
+                  }
                 />
               </NavigationMenuItem>
             ))}
@@ -118,7 +121,10 @@ export function Header() {
               size="sm"
               className="rounded-full"
               render={
-                <Link className="flex items-center gap-2" href={'/dashboard' as Route<string>}>
+                <ProtectedLink
+                  className="flex items-center gap-2"
+                  href={'/dashboard' as Route<string>}
+                >
                   {user?.avatarUrl ? (
                     <Image
                       className="size-6 rounded-full object-cover"
@@ -132,7 +138,7 @@ export function Header() {
                     <HugeiconsIcon className="size-4" icon={UserCircleIcon} />
                   )}
                   {userDashboardLabel}
-                </Link>
+                </ProtectedLink>
               }
             />
 
@@ -181,14 +187,14 @@ export function Header() {
         <div className="bg-background/95 absolute top-full right-4 left-4 mt-3 space-y-4 rounded-2xl border border-white/50 p-4 shadow-lg backdrop-blur-sm sm:right-6 sm:left-6">
           <nav className="flex flex-col gap-2">
             {NAV_ITEMS.map((item) => (
-              <Link
+              <ProtectedLink
                 key={item.href}
                 className="hover:bg-primary/10 rounded-lg px-3 py-2 text-sm font-medium transition-colors"
                 href={item.href as Route<string>}
                 onClick={() => setIsMobileMenuOpen(false)}
               >
                 {item.label}
-              </Link>
+              </ProtectedLink>
             ))}
           </nav>
 
@@ -258,7 +264,7 @@ export function Header() {
                   size="sm"
                   className="w-full justify-start rounded-xl"
                   render={
-                    <Link
+                    <ProtectedLink
                       className="flex w-full items-center gap-2"
                       href={'/dashboard' as Route<string>}
                     >
@@ -275,7 +281,7 @@ export function Header() {
                         <HugeiconsIcon className="size-4" icon={UserCircleIcon} />
                       )}
                       {userDashboardLabel}
-                    </Link>
+                    </ProtectedLink>
                   }
                 />
               </div>

--- a/apps/web/components/shared/protected-link.tsx
+++ b/apps/web/components/shared/protected-link.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { Route } from 'next';
+import type { ComponentPropsWithoutRef, MouseEvent } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { useAuth } from '@/hooks/use-auth';
+import {
+  getSignInPath,
+  isProtectedAppRoute,
+  savePendingAuthRedirectPath,
+} from '@/utils/auth-redirect';
+
+type ProtectedLinkProps = ComponentPropsWithoutRef<typeof Link>;
+
+export function ProtectedLink({ href, onClick, ...props }: ProtectedLinkProps) {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+  const hrefValue = href.toString();
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+
+    if (event.defaultPrevented || isAuthenticated || !isProtectedAppRoute(hrefValue)) {
+      return;
+    }
+
+    event.preventDefault();
+    savePendingAuthRedirectPath(hrefValue);
+    router.push(getSignInPath(hrefValue) as Route<string>);
+  };
+
+  return <Link href={href} onClick={handleClick} {...props} />;
+}

--- a/apps/web/lib/axios-instance.ts
+++ b/apps/web/lib/axios-instance.ts
@@ -5,6 +5,7 @@ import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 
 import { API_BASE_PATH, ENDPOINTS } from '@/constants/endpoints';
+import { getSignInPath } from '@/utils/auth-redirect';
 
 declare module 'axios' {
   export interface AxiosRequestConfig {
@@ -77,8 +78,8 @@ axiosInstance.interceptors.response.use(
       } catch (refreshError) {
         processQueue(refreshError);
         if (typeof window !== 'undefined') {
-          const callbackUrl = encodeURIComponent(window.location.pathname);
-          window.location.href = `/sign-in?callbackUrl=${callbackUrl}`;
+          const callbackUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+          window.location.href = getSignInPath(callbackUrl);
         }
         return Promise.reject(refreshError);
       } finally {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -2,24 +2,25 @@ import type { NextRequest } from 'next/server';
 
 import { NextResponse } from 'next/server';
 
+import { getSafeAuthRedirectPath, isProtectedAppRoute } from '@/utils/auth-redirect';
+
 export function proxy(request: NextRequest) {
   const token = request.cookies.get('access_token')?.value;
-  const { pathname } = request.nextUrl;
+  const { pathname, search } = request.nextUrl;
 
-  const protectedRoutes = ['/dashboard', '/roadmaps/generate'];
   const authRoutes = ['/sign-in', '/sign-up'];
 
-  const isProtectedRoute = protectedRoutes.some((route) => pathname.startsWith(route));
   const isAuthRoute = authRoutes.some((route) => pathname.startsWith(route));
 
-  if (isProtectedRoute && !token) {
+  if (isProtectedAppRoute(pathname) && !token) {
     const url = new URL('/sign-in', request.url);
-    url.searchParams.set('callbackUrl', pathname);
+    url.searchParams.set('callbackUrl', `${pathname}${search}`);
     return NextResponse.redirect(url);
   }
 
   if (isAuthRoute && token) {
-    return NextResponse.redirect(new URL('/', request.url));
+    const callbackUrl = request.nextUrl.searchParams.get('callbackUrl');
+    return NextResponse.redirect(new URL(getSafeAuthRedirectPath(callbackUrl), request.url));
   }
 
   return NextResponse.next();

--- a/apps/web/utils/auth-redirect.ts
+++ b/apps/web/utils/auth-redirect.ts
@@ -1,0 +1,113 @@
+const DEFAULT_AUTH_REDIRECT_PATH = '/';
+const AUTH_REDIRECT_STORAGE_KEY = 'rmap:auth-redirect';
+const AUTH_REDIRECT_STORAGE_TTL_MS = 10 * 60 * 1000;
+
+interface StoredAuthRedirect {
+  createdAt: number;
+  path: string;
+}
+
+export const PROTECTED_APP_ROUTES = ['/dashboard', '/roadmaps/generate'] as const;
+
+export function isProtectedAppRoute(path: string) {
+  return PROTECTED_APP_ROUTES.some((route) => path === route || path.startsWith(`${route}/`));
+}
+
+export function getSafeAuthRedirectPath(callbackUrl: null | string | undefined) {
+  if (!callbackUrl || !callbackUrl.startsWith('/') || callbackUrl.startsWith('//')) {
+    return DEFAULT_AUTH_REDIRECT_PATH;
+  }
+
+  try {
+    const url = new URL(callbackUrl, 'http://rmap.local');
+
+    if (url.origin !== 'http://rmap.local') {
+      return DEFAULT_AUTH_REDIRECT_PATH;
+    }
+
+    if (url.pathname === '/sign-in' || url.pathname === '/sign-up') {
+      return DEFAULT_AUTH_REDIRECT_PATH;
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return DEFAULT_AUTH_REDIRECT_PATH;
+  }
+}
+
+export function getSignInPath(callbackUrl: string) {
+  const safeCallbackUrl = getSafeAuthRedirectPath(callbackUrl);
+  const params = new URLSearchParams({ callbackUrl: safeCallbackUrl });
+
+  return `/sign-in?${params.toString()}`;
+}
+
+export function savePendingAuthRedirectPath(callbackUrl: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const safeCallbackUrl = getSafeAuthRedirectPath(callbackUrl);
+
+  if (safeCallbackUrl === DEFAULT_AUTH_REDIRECT_PATH) {
+    return;
+  }
+
+  const value: StoredAuthRedirect = {
+    createdAt: Date.now(),
+    path: safeCallbackUrl,
+  };
+
+  window.sessionStorage.setItem(AUTH_REDIRECT_STORAGE_KEY, JSON.stringify(value));
+}
+
+export function consumeAuthRedirectPath(callbackUrl: null | string | undefined) {
+  const safeCallbackUrl = getSafeAuthRedirectPath(callbackUrl);
+
+  if (safeCallbackUrl !== DEFAULT_AUTH_REDIRECT_PATH) {
+    clearPendingAuthRedirectPath();
+    return safeCallbackUrl;
+  }
+
+  const storedPath = getPendingAuthRedirectPath();
+  clearPendingAuthRedirectPath();
+
+  return storedPath ?? DEFAULT_AUTH_REDIRECT_PATH;
+}
+
+function clearPendingAuthRedirectPath() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.sessionStorage.removeItem(AUTH_REDIRECT_STORAGE_KEY);
+}
+
+function getPendingAuthRedirectPath() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const storedValue = window.sessionStorage.getItem(AUTH_REDIRECT_STORAGE_KEY);
+
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(storedValue) as Partial<StoredAuthRedirect>;
+    const isExpired =
+      typeof parsedValue.createdAt !== 'number' ||
+      Date.now() - parsedValue.createdAt > AUTH_REDIRECT_STORAGE_TTL_MS;
+
+    if (isExpired) {
+      return null;
+    }
+
+    const safePath = getSafeAuthRedirectPath(parsedValue.path);
+
+    return safePath === DEFAULT_AUTH_REDIRECT_PATH ? null : safePath;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

Fix: Corrects the login redirection flow for protected navigation.

Before: Clicking protected CTAs (Dashboard, Roadmap) prompted login but redirected users back to Home.

After: Users are now automatically routed to their intended destination after a successful sign-in.

## Related Issue

Closes #105 

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added shared auth redirect utilities for safe callback URL handling.
- Added a protected link wrapper for guarded Home/header navigation.
- Preserved the intended destination when unauthenticated users click protected CTAs.
- Updated sign-in and sign-up flows to redirect to the stored callback destination after auth.
- Updated proxy and axios auth redirect handling to keep callback URLs consistent.

## How to Test

Steps to verify:

1. Log out of the app.
2. From Home, click `Dashboard`, `Generate personalized roadmap`, or `Create your roadmap`.
3. Confirm the app opens the sign-in page.
4. Sign in with a valid account.
5. Confirm the app redirects to the originally selected destination instead of returning to Home.
6. Repeat with direct access to `/dashboard` and `/roadmaps/generate`.

## Screenshots (if FE)


https://github.com/user-attachments/assets/dec05bc1-057f-4589-930b-6056b745321a



## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

Verified with:

- `pnpm --filter web lint`
- `pnpm --filter web check-types`
- `pnpm --filter web build`
