### PR TITLE
Feature/108 add forgot password page

### DIFF
--- a/apps/web/app/(auth)/forgot-password/page.tsx
+++ b/apps/web/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { Route } from 'next';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowRight, Mail01Icon } from '@hugeicons/core-free-icons';
+import { AnimatedIconSwap } from '@repo/design-system/components/common/animated-icon-swap';
+import { Button } from '@repo/design-system/components/ui/button';
+import { Field, FieldError, FieldGroup, FieldLabel } from '@repo/design-system/components/ui/field';
+import { Input } from '@repo/design-system/components/ui/input';
+import { toast } from '@repo/design-system/lib/toast';
+import Link from 'next/link';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { authService } from '@/services/auth.service';
+import { type ForgotPasswordValues, forgotPasswordSchema } from '@/validations/auth.schema';
+
+export default function ForgotPasswordPage() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordValues>({
+    defaultValues: {
+      email: '',
+    },
+    resolver: zodResolver(forgotPasswordSchema),
+  });
+
+  const onSubmit = async (values: ForgotPasswordValues) => {
+    setIsSubmitting(true);
+
+    try {
+      await authService.forgotPassword(values);
+      toast.success('Reset link sent', {
+        description: 'If that email exists, reset instructions will arrive shortly.',
+      });
+    } catch {
+      toast.error('Request failed', {
+        description: 'Please try again in a moment.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-full flex-1 flex-col items-center justify-center pb-8 sm:pb-12">
+      <h1 className="font-heading text-foreground mb-8 text-center text-2xl leading-[1.325] font-semibold tracking-[-0.56px] sm:mb-12 sm:text-[28px]">
+        Reset Your Password
+      </h1>
+
+      <form
+        className="blur-wrapper-form flex w-full max-w-137.5 flex-col gap-6"
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <FieldGroup className="gap-6">
+          <Field data-invalid={!!errors.email}>
+            <FieldLabel className="text-base font-normal" htmlFor="email">
+              Email
+            </FieldLabel>
+            <Input
+              id="email"
+              placeholder="name@example.com"
+              type="email"
+              autoComplete="email"
+              aria-invalid={!!errors.email}
+              {...register('email')}
+            />
+            <FieldError errors={[errors.email]} />
+          </Field>
+
+          <Field>
+            <Button size="lg" className="group/btn w-full" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Sending...' : 'Send reset link'}
+              {!isSubmitting && <AnimatedIconSwap icon={ArrowRight} hoverIcon={Mail01Icon} />}
+            </Button>
+          </Field>
+        </FieldGroup>
+
+        <p className="text-muted-foreground text-center text-base leading-[1.4]">
+          Remember your password?{' '}
+          <Link
+            className="text-primary hover:text-primary-active mt-1.5 w-fit text-base leading-[1.4] hover:underline"
+            href={'/sign-in' as Route<string>}
+          >
+            Sign in
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/reset-password/page.tsx
+++ b/apps/web/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,14 @@
+import { ResetPasswordForm } from './reset-password-form';
+
+type ResetPasswordPageProps = {
+  searchParams: Promise<{
+    token?: string | string[];
+  }>;
+};
+
+export default async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
+  const params = await searchParams;
+  const token = Array.isArray(params.token) ? params.token[0] : params.token;
+
+  return <ResetPasswordForm token={token ?? ''} />;
+}

--- a/apps/web/app/(auth)/reset-password/page.tsx
+++ b/apps/web/app/(auth)/reset-password/page.tsx
@@ -8,7 +8,8 @@ type ResetPasswordPageProps = {
 
 export default async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
   const params = await searchParams;
-  const token = Array.isArray(params.token) ? params.token[0] : params.token;
+  const rawToken = Array.isArray(params.token) ? params.token[0] : params.token;
+  const token = rawToken?.trim() ?? '';
 
-  return <ResetPasswordForm token={token ?? ''} />;
+  return <ResetPasswordForm token={token} />;
 }

--- a/apps/web/app/(auth)/reset-password/reset-password-form.tsx
+++ b/apps/web/app/(auth)/reset-password/reset-password-form.tsx
@@ -56,7 +56,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
       toast.success('Password updated', {
         description: 'You can now sign in with your new password.',
       });
-      router.push('/sign-in');
+      router.replace('/sign-in');
     } catch {
       toast.error('Password reset failed', {
         description: 'The link may be expired or already used. Please request a new one.',

--- a/apps/web/app/(auth)/reset-password/reset-password-form.tsx
+++ b/apps/web/app/(auth)/reset-password/reset-password-form.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import type { Route } from 'next';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowRight, Login02FreeIcons } from '@hugeicons/core-free-icons';
+import { AnimatedIconSwap } from '@repo/design-system/components/common/animated-icon-swap';
+import { Button } from '@repo/design-system/components/ui/button';
+import { Field, FieldError, FieldGroup, FieldLabel } from '@repo/design-system/components/ui/field';
+import { toast } from '@repo/design-system/lib/toast';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { PasswordInput } from '@/app/(auth)/_components/password-input';
+import { authService } from '@/services/auth.service';
+import { type ResetPasswordValues, resetPasswordSchema } from '@/validations/auth.schema';
+
+type ResetPasswordFormProps = {
+  token: string;
+};
+
+export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const hasToken = token.length > 0;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordValues>({
+    defaultValues: {
+      confirmPassword: '',
+      password: '',
+    },
+    resolver: zodResolver(resetPasswordSchema),
+  });
+
+  const onSubmit = async (values: ResetPasswordValues) => {
+    if (!hasToken) {
+      toast.error('Reset link is invalid', {
+        description: 'Please request a new password reset link.',
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await authService.resetPassword({
+        newPassword: values.password,
+        token,
+      });
+      toast.success('Password updated', {
+        description: 'You can now sign in with your new password.',
+      });
+      router.push('/sign-in');
+    } catch {
+      toast.error('Password reset failed', {
+        description: 'The link may be expired or already used. Please request a new one.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-full flex-1 flex-col items-center justify-center pb-8 sm:pb-12">
+      <h1 className="font-heading text-foreground mb-4 text-center text-2xl leading-[1.325] font-semibold tracking-[-0.56px] sm:text-[28px]">
+        Create a New Password
+      </h1>
+
+      <p className="text-muted-foreground mb-8 max-w-137.5 text-center text-base leading-[1.5] sm:mb-12">
+        Choose a new password for your RMap account.
+      </p>
+
+      {!hasToken && (
+        <div className="border-destructive/30 bg-destructive/10 text-destructive mb-6 w-full max-w-137.5 rounded-lg border px-4 py-3 text-sm leading-[1.45]">
+          This reset link is missing its token. Please request a new password reset email.
+        </div>
+      )}
+
+      <form
+        className="blur-wrapper-form flex w-full max-w-137.5 flex-col gap-6"
+        noValidate
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <FieldGroup className="gap-6">
+          <Field data-invalid={!!errors.password}>
+            <FieldLabel className="text-base font-normal" htmlFor="password">
+              New Password
+            </FieldLabel>
+            <PasswordInput
+              id="password"
+              placeholder="Enter your new password"
+              autoComplete="new-password"
+              disabled={!hasToken || isSubmitting}
+              aria-invalid={!!errors.password}
+              {...register('password')}
+            />
+            <FieldError errors={[errors.password]} />
+          </Field>
+
+          <Field data-invalid={!!errors.confirmPassword}>
+            <FieldLabel className="text-base font-normal" htmlFor="confirm-password">
+              Confirm New Password
+            </FieldLabel>
+            <PasswordInput
+              id="confirm-password"
+              placeholder="Confirm your new password"
+              autoComplete="new-password"
+              disabled={!hasToken || isSubmitting}
+              aria-invalid={!!errors.confirmPassword}
+              {...register('confirmPassword')}
+            />
+            <FieldError errors={[errors.confirmPassword]} />
+          </Field>
+
+          <Field>
+            <Button
+              size="lg"
+              className="group/btn w-full"
+              type="submit"
+              disabled={!hasToken || isSubmitting}
+            >
+              {isSubmitting ? 'Updating...' : 'Update password'}
+              {!isSubmitting && <AnimatedIconSwap icon={ArrowRight} hoverIcon={Login02FreeIcons} />}
+            </Button>
+          </Field>
+        </FieldGroup>
+
+        <p className="text-muted-foreground text-center text-base leading-[1.4]">
+          Need a new link?{' '}
+          <Link
+            className="text-primary hover:text-primary-active mt-1.5 w-fit text-base leading-[1.4] hover:underline"
+            href={'/forgot-password' as Route<string>}
+          >
+            Request again
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/(auth)/sign-in/page.tsx
+++ b/apps/web/app/(auth)/sign-in/page.tsx
@@ -98,7 +98,7 @@ export default function SignInPage() {
               </FieldLabel>
               <Link
                 className="text-primary hover:text-primary-active text-sm font-medium hover:underline"
-                href={'/' as Route<string>}
+                href={'/forgot-password' as Route<string>}
               >
                 Forgot password?
               </Link>

--- a/apps/web/app/(auth)/sign-in/page.tsx
+++ b/apps/web/app/(auth)/sign-in/page.tsx
@@ -85,6 +85,7 @@ export default function SignInPage() {
               placeholder="name@example.com"
               type="email"
               autoComplete="email"
+              disabled={isSubmitting}
               aria-invalid={!!errors.email}
               {...register('email')}
             />

--- a/apps/web/constants/endpoints.ts
+++ b/apps/web/constants/endpoints.ts
@@ -12,6 +12,7 @@ export const ENDPOINTS = {
     },
     refresh: '/auth/refresh',
     register: '/auth/register',
+    resetPassword: '/auth/password/reset',
   },
   dashboard: '/dashboard',
   onboarding: {

--- a/apps/web/constants/endpoints.ts
+++ b/apps/web/constants/endpoints.ts
@@ -3,6 +3,7 @@ export const API_BASE_PATH = process.env.NEXT_PUBLIC_API_BASE_PATH ?? '/api/v1';
 export const ENDPOINTS = {
   auth: {
     changePassword: '/auth/password',
+    forgotPassword: '/auth/password/forgot',
     login: '/auth/login',
     logout: '/auth/logout',
     oauth: {

--- a/apps/web/services/auth.service.ts
+++ b/apps/web/services/auth.service.ts
@@ -4,6 +4,7 @@ import {
   type AuthApiUser,
   type ChangePasswordPayload,
   type ForgotPasswordPayload,
+  type ResetPasswordPayload,
   type SignInPayload,
   type SignUpPayload,
   type UpdateProfilePayload,
@@ -41,6 +42,9 @@ export const authService = {
   register: async (payload: SignUpPayload) => {
     const response = await axiosInstance.post<AuthApiUser>(ENDPOINTS.auth.register, payload);
     return response.data;
+  },
+  resetPassword: async (payload: ResetPasswordPayload) => {
+    await axiosInstance.post<void>(ENDPOINTS.auth.resetPassword, payload);
   },
   updateProfile: async (payload: UpdateProfilePayload) => {
     const response = await axiosInstance.patch<AuthApiUser>(ENDPOINTS.users.me, payload);

--- a/apps/web/services/auth.service.ts
+++ b/apps/web/services/auth.service.ts
@@ -3,6 +3,7 @@ import { axiosInstance } from '@/lib/axios-instance';
 import {
   type AuthApiUser,
   type ChangePasswordPayload,
+  type ForgotPasswordPayload,
   type SignInPayload,
   type SignUpPayload,
   type UpdateProfilePayload,
@@ -23,6 +24,9 @@ export const authService = {
   },
   login: async (payload: SignInPayload) => {
     await axiosInstance.post<void>(ENDPOINTS.auth.login, payload);
+  },
+  forgotPassword: async (payload: ForgotPasswordPayload) => {
+    await axiosInstance.post<void>(ENDPOINTS.auth.forgotPassword, payload);
   },
   logout: async () => {
     await axiosInstance.post<void>(ENDPOINTS.auth.logout);

--- a/apps/web/types/auth.ts
+++ b/apps/web/types/auth.ts
@@ -41,6 +41,10 @@ export interface SignInPayload {
   password: string;
 }
 
+export interface ForgotPasswordPayload {
+  email: string;
+}
+
 export interface SignUpPayload {
   avatarUrl?: string;
   email: string;

--- a/apps/web/types/auth.ts
+++ b/apps/web/types/auth.ts
@@ -45,6 +45,11 @@ export interface ForgotPasswordPayload {
   email: string;
 }
 
+export interface ResetPasswordPayload {
+  newPassword: string;
+  token: string;
+}
+
 export interface SignUpPayload {
   avatarUrl?: string;
   email: string;

--- a/apps/web/validations/auth.schema.ts
+++ b/apps/web/validations/auth.schema.ts
@@ -5,6 +5,10 @@ export const signInSchema = z.object({
   password: z.string().min(1, 'Password is required'),
 });
 
+export const forgotPasswordSchema = z.object({
+  email: z.string().email('Please enter a valid email'),
+});
+
 export const signUpSchema = z
   .object({
     confirmPassword: z.string().min(1, 'Please confirm your password'),
@@ -21,4 +25,5 @@ export const signUpSchema = z
   });
 
 export type SignInValues = z.infer<typeof signInSchema>;
+export type ForgotPasswordValues = z.infer<typeof forgotPasswordSchema>;
 export type SignUpValues = z.infer<typeof signUpSchema>;

--- a/apps/web/validations/auth.schema.ts
+++ b/apps/web/validations/auth.schema.ts
@@ -9,6 +9,16 @@ export const forgotPasswordSchema = z.object({
   email: z.string().email('Please enter a valid email'),
 });
 
+export const resetPasswordSchema = z
+  .object({
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+  })
+  .refine((values) => values.password === values.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
 export const signUpSchema = z
   .object({
     confirmPassword: z.string().min(1, 'Please confirm your password'),
@@ -26,4 +36,5 @@ export const signUpSchema = z
 
 export type SignInValues = z.infer<typeof signInSchema>;
 export type ForgotPasswordValues = z.infer<typeof forgotPasswordSchema>;
+export type ResetPasswordValues = z.infer<typeof resetPasswordSchema>;
 export type SignUpValues = z.infer<typeof signUpSchema>;


### PR DESCRIPTION
## Description

Adds the frontend password recovery flow so users can request a password reset email and complete password reset from the link sent to their inbox.

## Related Issue

Closes #108 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- Added forgot password request flow support on the frontend.
- Added `/reset-password?token=...` page for users to enter a new password.
- Added reset password form validation with password confirmation.
- Connected frontend auth service to `POST /auth/password/reset`.
- Added handling for missing, expired, or already-used reset tokens.

## How to Test

Steps to verify:

1. Go to `/forgot-password`.
2. Submit a valid account email and confirm the success toast appears.
3. Open the reset password link from the email.
4. Enter and confirm a new password with at least 8 characters.
5. Submit the form and confirm the user is redirected to `/sign-in`.
6. Sign in with the new password.
7. Open `/reset-password` without a token and confirm the invalid link state appears.

## Screenshots (if FE)


https://github.com/user-attachments/assets/3c59d7ff-fe26-4042-b721-f4c097471d7f



## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

Password reset links expire after 15 minutes based on `PASSWORD_RESET_TOKEN_TTL_MINUTES`. A token can only be used once, and requesting a new reset link invalidates previous active reset tokens for that user.
