### PR TITLE
[FEATURE] Add admin skills catalog CRUD with prerequisite management

### DIFF
--- a/apps/api/src/common/constants/error-codes.ts
+++ b/apps/api/src/common/constants/error-codes.ts
@@ -46,12 +46,18 @@ export enum ErrorCode {
   ROADMAP_NODE_NOT_FOUND = 40406,
   USER_NODE_PROGRESS_NOT_FOUND = 40407,
   OAUTH_INTEGRATION_NOT_CONNECTED = 40408,
+  SKILL_PREREQUISITE_NOT_FOUND = 40409,
   // 409 - Conflict
   CONFLICT = 40900,
   EMAIL_ALREADY_EXISTS = 40901,
   REFRESH_TOKEN_ALREADY_EXISTS = 40902,
   OAUTH_PROVIDER_ALREADY_CONNECTED = 40903,
   OAUTH_ACCOUNT_ALREADY_CONNECTED = 40904,
+  SKILL_NAME_ALREADY_EXISTS = 40905,
+  SKILL_DELETE_REFERENCED = 40906,
+  SKILL_PREREQUISITE_ALREADY_EXISTS = 40907,
+  SKILL_PREREQUISITE_SELF_REFERENCE = 40908,
+  SKILL_PREREQUISITE_CYCLE = 40909,
   // 429 - Too Many Requests
   RATE_LIMIT_EXCEEDED = 42900,
   TOO_MANY_MESSAGES = 42901,
@@ -118,6 +124,7 @@ export const ErrorMessages: Record<ErrorCode, string> = {
   [ErrorCode.ROADMAP_NODE_NOT_FOUND]: 'Roadmap node not found',
   [ErrorCode.USER_NODE_PROGRESS_NOT_FOUND]: 'User node progress not found',
   [ErrorCode.OAUTH_INTEGRATION_NOT_CONNECTED]: 'OAuth integration is not connected',
+  [ErrorCode.SKILL_PREREQUISITE_NOT_FOUND]: 'Skill prerequisite relationship not found',
   // 409 - Conflict
   [ErrorCode.CONFLICT]: 'The resource is in a conflicting state',
   [ErrorCode.EMAIL_ALREADY_EXISTS]: 'Email already registered',
@@ -125,6 +132,12 @@ export const ErrorMessages: Record<ErrorCode, string> = {
   [ErrorCode.OAUTH_PROVIDER_ALREADY_CONNECTED]:
     'OAuth provider is already connected to this account',
   [ErrorCode.OAUTH_ACCOUNT_ALREADY_CONNECTED]: 'OAuth account is already connected',
+  [ErrorCode.SKILL_NAME_ALREADY_EXISTS]: 'Skill name already exists',
+  [ErrorCode.SKILL_DELETE_REFERENCED]:
+    'Skill cannot be deleted because it is referenced by roadmap or template nodes',
+  [ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS]: 'Skill prerequisite relationship already exists',
+  [ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE]: 'A skill cannot be a prerequisite of itself',
+  [ErrorCode.SKILL_PREREQUISITE_CYCLE]: 'Skill prerequisite relationship would introduce a cycle',
   // 429 - Too Many Requests
   [ErrorCode.RATE_LIMIT_EXCEEDED]: 'Rate limit exceeded',
   [ErrorCode.TOO_MANY_MESSAGES]: 'Too many messages sent',

--- a/apps/api/src/common/exceptions/app.exceptions.ts
+++ b/apps/api/src/common/exceptions/app.exceptions.ts
@@ -379,6 +379,15 @@ export class SkillNotFoundException extends NotFoundException {
   }
 }
 
+export class SkillPrerequisiteNotFoundException extends NotFoundException {
+  constructor(skillId: number | string, prerequisiteSkillId: number | string) {
+    super({
+      code: ErrorCode.SKILL_PREREQUISITE_NOT_FOUND,
+      message: `${getErrorMessage(ErrorCode.SKILL_PREREQUISITE_NOT_FOUND)}: ${skillId} -> ${prerequisiteSkillId}`,
+    });
+  }
+}
+
 export class ResourceNotFoundException extends NotFoundException {
   constructor(identifier: number | string) {
     super({
@@ -410,6 +419,24 @@ export class AppConflictException extends ConflictException {
   }
 }
 
+export class SkillNameAlreadyExistsException extends ConflictException {
+  constructor(name: string) {
+    super({
+      code: ErrorCode.SKILL_NAME_ALREADY_EXISTS,
+      message: `${getErrorMessage(ErrorCode.SKILL_NAME_ALREADY_EXISTS)}: ${name}`,
+    });
+  }
+}
+
+export class SkillDeleteReferencedException extends ConflictException {
+  constructor() {
+    super({
+      code: ErrorCode.SKILL_DELETE_REFERENCED,
+      message: getErrorMessage(ErrorCode.SKILL_DELETE_REFERENCED),
+    });
+  }
+}
+
 export class RefreshTokenAlreadyExistsException extends ConflictException {
   constructor() {
     super({
@@ -433,6 +460,33 @@ export class OAuthAccountAlreadyConnectedException extends ConflictException {
     super({
       code: ErrorCode.OAUTH_ACCOUNT_ALREADY_CONNECTED,
       message: `${getErrorMessage(ErrorCode.OAUTH_ACCOUNT_ALREADY_CONNECTED)}: ${provider}`,
+    });
+  }
+}
+
+export class SkillPrerequisiteAlreadyExistsException extends ConflictException {
+  constructor() {
+    super({
+      code: ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS,
+      message: getErrorMessage(ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS),
+    });
+  }
+}
+
+export class SkillPrerequisiteSelfReferenceException extends ConflictException {
+  constructor() {
+    super({
+      code: ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE,
+      message: getErrorMessage(ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE),
+    });
+  }
+}
+
+export class SkillPrerequisiteCycleException extends ConflictException {
+  constructor() {
+    super({
+      code: ErrorCode.SKILL_PREREQUISITE_CYCLE,
+      message: getErrorMessage(ErrorCode.SKILL_PREREQUISITE_CYCLE),
     });
   }
 }
@@ -643,6 +697,7 @@ export const ErrorCodeToException = {
   [ErrorCode.USER_NODE_PROGRESS_NOT_FOUND]: UserNodeProgressNotFoundException,
   [ErrorCode.OAUTH_INTEGRATION_NOT_CONNECTED]: OAuthIntegrationNotConnectedException,
   [ErrorCode.SKILL_NOT_FOUND]: SkillNotFoundException,
+  [ErrorCode.SKILL_PREREQUISITE_NOT_FOUND]: SkillPrerequisiteNotFoundException,
   [ErrorCode.ROLE_NOT_FOUND]: RoleNotFoundException,
   [ErrorCode.RESOURCE_NOT_FOUND]: ResourceNotFoundException,
   // 409 - Conflict
@@ -651,6 +706,11 @@ export const ErrorCodeToException = {
   [ErrorCode.REFRESH_TOKEN_ALREADY_EXISTS]: RefreshTokenAlreadyExistsException,
   [ErrorCode.OAUTH_PROVIDER_ALREADY_CONNECTED]: OAuthProviderAlreadyConnectedException,
   [ErrorCode.OAUTH_ACCOUNT_ALREADY_CONNECTED]: OAuthAccountAlreadyConnectedException,
+  [ErrorCode.SKILL_NAME_ALREADY_EXISTS]: SkillNameAlreadyExistsException,
+  [ErrorCode.SKILL_DELETE_REFERENCED]: SkillDeleteReferencedException,
+  [ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS]: SkillPrerequisiteAlreadyExistsException,
+  [ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE]: SkillPrerequisiteSelfReferenceException,
+  [ErrorCode.SKILL_PREREQUISITE_CYCLE]: SkillPrerequisiteCycleException,
   // 429 - Too Many Requests
   [ErrorCode.RATE_LIMIT_EXCEEDED]: RateLimitExceededException,
   [ErrorCode.TOO_MANY_MESSAGES]: TooManyMessagesException,

--- a/apps/api/src/modules/skills/admin-skill-prerequisites.controller.ts
+++ b/apps/api/src/modules/skills/admin-skill-prerequisites.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import { UserRole } from '@repo/db/prisma/client';
+
+import { Roles } from '@/common/decorators/roles.decorator';
+
+import type { SkillPrerequisiteListResponse } from './types/admin-skill-prerequisite-response.types';
+
+import { AdminSkillPrerequisitesService } from './admin-skill-prerequisites.service';
+import {
+  SkillPrerequisiteListParamsDto,
+  SkillPrerequisiteParamsDto,
+} from './dto/admin-skill-prerequisite-params.dto';
+import { CreateSkillPrerequisiteDto } from './dto/admin-skill-prerequisite.dto';
+
+@Controller('admin/skills/:skillId/prerequisites')
+@Roles(UserRole.ADMIN)
+export class AdminSkillPrerequisitesController {
+  constructor(private readonly adminSkillPrerequisitesService: AdminSkillPrerequisitesService) {}
+
+  @Get()
+  async list(
+    @Param() params: SkillPrerequisiteListParamsDto,
+  ): Promise<SkillPrerequisiteListResponse> {
+    return this.adminSkillPrerequisitesService.listPrerequisites(params.skillId);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Param() params: SkillPrerequisiteListParamsDto,
+    @Body() dto: CreateSkillPrerequisiteDto,
+  ): Promise<void> {
+    await this.adminSkillPrerequisitesService.createPrerequisite(params.skillId, dto);
+  }
+
+  @Delete(':prereqSkillId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param() params: SkillPrerequisiteParamsDto): Promise<void> {
+    await this.adminSkillPrerequisitesService.deletePrerequisite(
+      params.skillId,
+      params.prereqSkillId,
+    );
+  }
+}

--- a/apps/api/src/modules/skills/admin-skill-prerequisites.service.ts
+++ b/apps/api/src/modules/skills/admin-skill-prerequisites.service.ts
@@ -2,8 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { Prisma, type RoleCategory } from '@repo/db/prisma/client';
 
 import {
-  AppConflictException,
-  AppNotFoundException,
+  SkillPrerequisiteAlreadyExistsException,
+  SkillPrerequisiteCycleException,
+  SkillPrerequisiteNotFoundException,
+  SkillPrerequisiteSelfReferenceException,
   SkillNotFoundException,
 } from '@/common/exceptions/app.exceptions';
 import { PrismaService } from '@/modules/prisma/prisma.service';
@@ -70,7 +72,7 @@ export class AdminSkillPrerequisitesService {
         await this.findSkillOrThrow(skillId, tx);
 
         if (skillId === dto.prerequisiteSkillId) {
-          throw new AppConflictException('A skill cannot be a prerequisite of itself');
+          throw new SkillPrerequisiteSelfReferenceException();
         }
 
         await this.findSkillOrThrow(dto.prerequisiteSkillId, tx);
@@ -90,7 +92,7 @@ export class AdminSkillPrerequisitesService {
       });
     } catch (error) {
       if (this.isPrismaErrorCode(error, 'P2002')) {
-        throw new AppConflictException('Prerequisite relationship already exists');
+        throw new SkillPrerequisiteAlreadyExistsException();
       }
 
       throw error;
@@ -109,9 +111,7 @@ export class AdminSkillPrerequisitesService {
     });
 
     if (result.count === 0) {
-      throw new AppNotFoundException(
-        `Prerequisite relationship not found: ${skillId} -> ${prereqSkillId}`,
-      );
+      throw new SkillPrerequisiteNotFoundException(skillId, prereqSkillId);
     }
   }
 
@@ -179,7 +179,7 @@ export class AdminSkillPrerequisitesService {
     });
 
     if (existing) {
-      throw new AppConflictException('Prerequisite relationship already exists');
+      throw new SkillPrerequisiteAlreadyExistsException();
     }
   }
 
@@ -189,7 +189,7 @@ export class AdminSkillPrerequisitesService {
     prisma: SkillPrerequisitePrismaClient,
   ): Promise<void> {
     if (await this.isSkillReachable(prerequisiteSkillId, skillId, prisma)) {
-      throw new AppConflictException('Prerequisite relationship would introduce a cycle');
+      throw new SkillPrerequisiteCycleException();
     }
   }
 

--- a/apps/api/src/modules/skills/admin-skill-prerequisites.service.ts
+++ b/apps/api/src/modules/skills/admin-skill-prerequisites.service.ts
@@ -1,0 +1,233 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, type RoleCategory } from '@repo/db/prisma/client';
+
+import {
+  AppConflictException,
+  AppNotFoundException,
+  SkillNotFoundException,
+} from '@/common/exceptions/app.exceptions';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+
+import type { CreateSkillPrerequisiteDto } from './dto/admin-skill-prerequisite.dto';
+import type { SkillPrerequisiteListResponse } from './types/admin-skill-prerequisite-response.types';
+import type { SkillResponse } from './types/admin-skill-response.types';
+
+const SKILL_SELECT = {
+  createdAt: true,
+  defaultEstimatedHours: true,
+  description: true,
+  id: true,
+  name: true,
+  roleCategory: true,
+  updatedAt: true,
+} satisfies Prisma.SkillSelect;
+
+type DecimalLike = {
+  toNumber?: () => number;
+  toString: () => string;
+};
+
+type SkillRecord = {
+  createdAt: Date;
+  defaultEstimatedHours: DecimalLike | null | number;
+  description: null | string;
+  id: string;
+  name: string;
+  roleCategory: null | RoleCategory;
+  updatedAt: Date;
+};
+
+type SkillPrerequisitePrismaClient = Pick<PrismaService, 'skill' | 'skillPrerequisite'>;
+
+@Injectable()
+export class AdminSkillPrerequisitesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listPrerequisites(skillId: string): Promise<SkillPrerequisiteListResponse> {
+    await this.findSkillOrThrow(skillId);
+
+    const prerequisites = await this.prisma.skillPrerequisite.findMany({
+      orderBy: [{ prerequisiteSkill: { name: 'asc' } }, { prerequisiteSkillId: 'asc' }],
+      select: {
+        prerequisiteSkill: {
+          select: SKILL_SELECT,
+        },
+      },
+      where: { skillId },
+    });
+
+    return {
+      prerequisites: prerequisites.map((prerequisite) =>
+        this.formatSkill(prerequisite.prerequisiteSkill),
+      ),
+      skillId,
+    };
+  }
+
+  async createPrerequisite(skillId: string, dto: CreateSkillPrerequisiteDto): Promise<void> {
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await this.findSkillOrThrow(skillId, tx);
+
+        if (skillId === dto.prerequisiteSkillId) {
+          throw new AppConflictException('A skill cannot be a prerequisite of itself');
+        }
+
+        await this.findSkillOrThrow(dto.prerequisiteSkillId, tx);
+        await this.throwIfPrerequisiteExists(skillId, dto.prerequisiteSkillId, tx);
+        await this.throwIfPrerequisiteCreatesCycle(skillId, dto.prerequisiteSkillId, tx);
+
+        await tx.skillPrerequisite.create({
+          data: {
+            prerequisiteSkillId: dto.prerequisiteSkillId,
+            skillId,
+          },
+          select: {
+            prerequisiteSkillId: true,
+            skillId: true,
+          },
+        });
+      });
+    } catch (error) {
+      if (this.isPrismaErrorCode(error, 'P2002')) {
+        throw new AppConflictException('Prerequisite relationship already exists');
+      }
+
+      throw error;
+    }
+  }
+
+  async deletePrerequisite(skillId: string, prereqSkillId: string): Promise<void> {
+    await this.findSkillOrThrow(skillId);
+    await this.findSkillOrThrow(prereqSkillId);
+
+    const result = await this.prisma.skillPrerequisite.deleteMany({
+      where: {
+        prerequisiteSkillId: prereqSkillId,
+        skillId,
+      },
+    });
+
+    if (result.count === 0) {
+      throw new AppNotFoundException(
+        `Prerequisite relationship not found: ${skillId} -> ${prereqSkillId}`,
+      );
+    }
+  }
+
+  private async findSkillOrThrow(
+    skillId: string,
+    prisma: Pick<PrismaService, 'skill'> = this.prisma,
+  ): Promise<void> {
+    const skill = await prisma.skill.findUnique({
+      select: { id: true },
+      where: { id: skillId },
+    });
+
+    if (!skill) {
+      throw new SkillNotFoundException(skillId);
+    }
+  }
+
+  private formatSkill(skill: SkillRecord): SkillResponse {
+    return {
+      createdAt: skill.createdAt.toISOString(),
+      defaultEstimatedHours: this.formatDecimal(skill.defaultEstimatedHours),
+      description: skill.description,
+      id: skill.id,
+      name: skill.name,
+      roleCategory: skill.roleCategory,
+      updatedAt: skill.updatedAt.toISOString(),
+    };
+  }
+
+  private formatDecimal(value: DecimalLike | null | number): null | number {
+    if (value === null) {
+      return null;
+    }
+
+    return typeof value === 'number'
+      ? value
+      : typeof value.toNumber === 'function'
+        ? value.toNumber()
+        : Number(value.toString());
+  }
+
+  private isPrismaErrorCode(
+    error: unknown,
+    code: string,
+  ): error is Prisma.PrismaClientKnownRequestError {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === code;
+  }
+
+  private async throwIfPrerequisiteExists(
+    skillId: string,
+    prerequisiteSkillId: string,
+    prisma: SkillPrerequisitePrismaClient,
+  ): Promise<void> {
+    const existing = await prisma.skillPrerequisite.findUnique({
+      select: {
+        prerequisiteSkillId: true,
+        skillId: true,
+      },
+      where: {
+        skillId_prerequisiteSkillId: {
+          prerequisiteSkillId,
+          skillId,
+        },
+      },
+    });
+
+    if (existing) {
+      throw new AppConflictException('Prerequisite relationship already exists');
+    }
+  }
+
+  private async throwIfPrerequisiteCreatesCycle(
+    skillId: string,
+    prerequisiteSkillId: string,
+    prisma: SkillPrerequisitePrismaClient,
+  ): Promise<void> {
+    if (await this.isSkillReachable(prerequisiteSkillId, skillId, prisma)) {
+      throw new AppConflictException('Prerequisite relationship would introduce a cycle');
+    }
+  }
+
+  private async isSkillReachable(
+    startSkillId: string,
+    targetSkillId: string,
+    prisma: SkillPrerequisitePrismaClient,
+  ): Promise<boolean> {
+    const visited = new Set<string>([startSkillId]);
+    let frontier = [startSkillId];
+
+    while (frontier.length > 0) {
+      const edges = await prisma.skillPrerequisite.findMany({
+        select: {
+          prerequisiteSkillId: true,
+        },
+        where: {
+          skillId: {
+            in: frontier,
+          },
+        },
+      });
+      const nextFrontier: string[] = [];
+
+      for (const edge of edges) {
+        if (edge.prerequisiteSkillId === targetSkillId) {
+          return true;
+        }
+
+        if (!visited.has(edge.prerequisiteSkillId)) {
+          visited.add(edge.prerequisiteSkillId);
+          nextFrontier.push(edge.prerequisiteSkillId);
+        }
+      }
+
+      frontier = nextFrontier;
+    }
+
+    return false;
+  }
+}

--- a/apps/api/src/modules/skills/admin-skills.controller.ts
+++ b/apps/api/src/modules/skills/admin-skills.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import { UserRole } from '@repo/db/prisma/client';
+
+import { Roles } from '@/common/decorators/roles.decorator';
+
+import type {
+  AdminSkillsListResponse,
+  SkillDetailResponse,
+  SkillResponse,
+} from './types/admin-skill-response.types';
+
+import { AdminSkillsService } from './admin-skills.service';
+import { SkillIdParamDto } from './dto/admin-skill-params.dto';
+import { ListAdminSkillsQueryDto } from './dto/admin-skill-query.dto';
+import { CreateSkillDto, UpdateSkillDto } from './dto/admin-skill.dto';
+
+@Controller('admin/skills')
+@Roles(UserRole.ADMIN)
+export class AdminSkillsController {
+  constructor(private readonly adminSkillsService: AdminSkillsService) {}
+
+  @Get()
+  async list(@Query() query: ListAdminSkillsQueryDto): Promise<AdminSkillsListResponse> {
+    return this.adminSkillsService.listSkills(query);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(@Body() dto: CreateSkillDto): Promise<SkillResponse> {
+    return this.adminSkillsService.createSkill(dto);
+  }
+
+  @Get(':skillId')
+  async get(@Param() params: SkillIdParamDto): Promise<SkillDetailResponse> {
+    return this.adminSkillsService.getSkill(params.skillId);
+  }
+
+  @Put(':skillId')
+  async update(
+    @Param() params: SkillIdParamDto,
+    @Body() dto: UpdateSkillDto,
+  ): Promise<SkillResponse> {
+    return this.adminSkillsService.updateSkill(params.skillId, dto);
+  }
+
+  @Delete(':skillId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param() params: SkillIdParamDto): Promise<void> {
+    await this.adminSkillsService.deleteSkill(params.skillId);
+  }
+}

--- a/apps/api/src/modules/skills/admin-skills.service.ts
+++ b/apps/api/src/modules/skills/admin-skills.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma, type RoleCategory } from '@repo/db/prisma/client';
 
-import { AppConflictException, SkillNotFoundException } from '@/common/exceptions/app.exceptions';
+import {
+  SkillDeleteReferencedException,
+  SkillNameAlreadyExistsException,
+  SkillNotFoundException,
+} from '@/common/exceptions/app.exceptions';
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
 import type { ListAdminSkillsQueryDto } from './dto/admin-skill-query.dto';
@@ -163,9 +167,7 @@ export class AdminSkillsService {
     });
 
     if (referencedNode) {
-      throw new AppConflictException(
-        'Skill cannot be deleted because it is referenced by roadmap or template nodes',
-      );
+      throw new SkillDeleteReferencedException();
     }
 
     try {
@@ -267,6 +269,6 @@ export class AdminSkillsService {
       return;
     }
 
-    throw new AppConflictException(`A skill with this name already exists: ${name}`);
+    throw new SkillNameAlreadyExistsException(name);
   }
 }

--- a/apps/api/src/modules/skills/admin-skills.service.ts
+++ b/apps/api/src/modules/skills/admin-skills.service.ts
@@ -1,0 +1,272 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, type RoleCategory } from '@repo/db/prisma/client';
+
+import { AppConflictException, SkillNotFoundException } from '@/common/exceptions/app.exceptions';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+
+import type { ListAdminSkillsQueryDto } from './dto/admin-skill-query.dto';
+import type { CreateSkillDto, UpdateSkillDto } from './dto/admin-skill.dto';
+import type {
+  AdminSkillsListResponse,
+  SkillDetailResponse,
+  SkillResponse,
+} from './types/admin-skill-response.types';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PER_PAGE = 20;
+
+const SKILL_SELECT = {
+  createdAt: true,
+  defaultEstimatedHours: true,
+  description: true,
+  id: true,
+  name: true,
+  roleCategory: true,
+  updatedAt: true,
+} satisfies Prisma.SkillSelect;
+
+const SKILL_DETAIL_SELECT = {
+  ...SKILL_SELECT,
+  prerequisites: {
+    select: {
+      prerequisiteSkill: {
+        select: {
+          name: true,
+        },
+      },
+      prerequisiteSkillId: true,
+    },
+  },
+} satisfies Prisma.SkillSelect;
+
+type DecimalLike = {
+  toNumber?: () => number;
+  toString: () => string;
+};
+
+type SkillRecord = {
+  createdAt: Date;
+  defaultEstimatedHours: DecimalLike | null | number;
+  description: null | string;
+  id: string;
+  name: string;
+  roleCategory: null | RoleCategory;
+  updatedAt: Date;
+};
+
+type SkillDetailRecord = SkillRecord & {
+  prerequisites: Array<{
+    prerequisiteSkill: {
+      name: string;
+    };
+    prerequisiteSkillId: string;
+  }>;
+};
+
+@Injectable()
+export class AdminSkillsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listSkills(query: ListAdminSkillsQueryDto): Promise<AdminSkillsListResponse> {
+    const page = query.page ?? DEFAULT_PAGE;
+    const perPage = query.perPage ?? DEFAULT_PER_PAGE;
+    const where = this.buildSkillWhere(query);
+
+    const [skills, total] = await this.prisma.$transaction([
+      this.prisma.skill.findMany({
+        orderBy: [{ name: 'asc' }, { id: 'asc' }],
+        select: SKILL_SELECT,
+        skip: (page - 1) * perPage,
+        take: perPage,
+        where,
+      }),
+      this.prisma.skill.count({ where }),
+    ]);
+
+    return {
+      data: skills.map((skill) => this.formatSkill(skill)),
+      meta: {
+        page,
+        perPage,
+        total,
+        totalPages: Math.ceil(total / perPage),
+      },
+    };
+  }
+
+  async createSkill(dto: CreateSkillDto): Promise<SkillResponse> {
+    try {
+      const skill = await this.prisma.skill.create({
+        data: {
+          defaultEstimatedHours: dto.defaultEstimatedHours ?? null,
+          description: dto.description ?? null,
+          name: dto.name,
+          roleCategory: dto.roleCategory,
+        },
+        select: SKILL_SELECT,
+      });
+
+      return this.formatSkill(skill);
+    } catch (error) {
+      this.throwSkillNameConflictIfNeeded(error, dto.name);
+      throw error;
+    }
+  }
+
+  async getSkill(skillId: string): Promise<SkillDetailResponse> {
+    const skill = await this.prisma.skill.findUnique({
+      select: SKILL_DETAIL_SELECT,
+      where: { id: skillId },
+    });
+
+    if (!skill) {
+      throw new SkillNotFoundException(skillId);
+    }
+
+    return this.formatSkillDetail(skill);
+  }
+
+  async updateSkill(skillId: string, dto: UpdateSkillDto): Promise<SkillResponse> {
+    await this.findSkillOrThrow(skillId);
+
+    try {
+      const skill = await this.prisma.skill.update({
+        data: {
+          ...(this.hasOwn(dto, 'defaultEstimatedHours')
+            ? { defaultEstimatedHours: dto.defaultEstimatedHours ?? null }
+            : {}),
+          ...(this.hasOwn(dto, 'description') ? { description: dto.description ?? null } : {}),
+          ...(this.hasOwn(dto, 'name') ? { name: dto.name } : {}),
+          ...(this.hasOwn(dto, 'roleCategory') ? { roleCategory: dto.roleCategory } : {}),
+        },
+        select: SKILL_SELECT,
+        where: { id: skillId },
+      });
+
+      return this.formatSkill(skill);
+    } catch (error) {
+      if (this.isPrismaErrorCode(error, 'P2025')) {
+        throw new SkillNotFoundException(skillId);
+      }
+
+      this.throwSkillNameConflictIfNeeded(error, dto.name);
+      throw error;
+    }
+  }
+
+  async deleteSkill(skillId: string): Promise<void> {
+    await this.findSkillOrThrow(skillId);
+
+    const referencedNode = await this.prisma.roadmapNode.findFirst({
+      select: { id: true },
+      where: { skillId },
+    });
+
+    if (referencedNode) {
+      throw new AppConflictException(
+        'Skill cannot be deleted because it is referenced by roadmap or template nodes',
+      );
+    }
+
+    try {
+      await this.prisma.skill.delete({
+        select: { id: true },
+        where: { id: skillId },
+      });
+    } catch (error) {
+      if (this.isPrismaErrorCode(error, 'P2025')) {
+        throw new SkillNotFoundException(skillId);
+      }
+
+      throw error;
+    }
+  }
+
+  private buildSkillWhere(query: ListAdminSkillsQueryDto): Prisma.SkillWhereInput {
+    const where: Prisma.SkillWhereInput = {};
+    const searchQuery = query.q?.trim();
+
+    if (query.roleCategory) {
+      where.roleCategory = query.roleCategory;
+    }
+
+    if (searchQuery) {
+      where.name = {
+        contains: searchQuery,
+        mode: 'insensitive',
+      };
+    }
+
+    return where;
+  }
+
+  private async findSkillOrThrow(skillId: string): Promise<void> {
+    const skill = await this.prisma.skill.findUnique({
+      select: { id: true },
+      where: { id: skillId },
+    });
+
+    if (!skill) {
+      throw new SkillNotFoundException(skillId);
+    }
+  }
+
+  private formatSkill(skill: SkillRecord): SkillResponse {
+    return {
+      createdAt: skill.createdAt.toISOString(),
+      defaultEstimatedHours: this.formatDecimal(skill.defaultEstimatedHours),
+      description: skill.description,
+      id: skill.id,
+      name: skill.name,
+      roleCategory: skill.roleCategory,
+      updatedAt: skill.updatedAt.toISOString(),
+    };
+  }
+
+  private formatSkillDetail(skill: SkillDetailRecord): SkillDetailResponse {
+    const orderedPrerequisites = [...skill.prerequisites].sort(
+      (a, b) =>
+        a.prerequisiteSkill.name.localeCompare(b.prerequisiteSkill.name) ||
+        a.prerequisiteSkillId.localeCompare(b.prerequisiteSkillId),
+    );
+
+    return {
+      ...this.formatSkill(skill),
+      prerequisites: orderedPrerequisites.map((prerequisite) => ({
+        name: prerequisite.prerequisiteSkill.name,
+        skillId: prerequisite.prerequisiteSkillId,
+      })),
+    };
+  }
+
+  private formatDecimal(value: DecimalLike | null | number): null | number {
+    if (value === null) {
+      return null;
+    }
+
+    return typeof value === 'number'
+      ? value
+      : typeof value.toNumber === 'function'
+        ? value.toNumber()
+        : Number(value.toString());
+  }
+
+  private hasOwn(object: object, key: string): boolean {
+    return Object.hasOwn(object, key) && (object as Record<string, unknown>)[key] !== undefined;
+  }
+
+  private isPrismaErrorCode(
+    error: unknown,
+    code: string,
+  ): error is Prisma.PrismaClientKnownRequestError {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === code;
+  }
+
+  private throwSkillNameConflictIfNeeded(error: unknown, name: string | undefined): void {
+    if (!name || !this.isPrismaErrorCode(error, 'P2002')) {
+      return;
+    }
+
+    throw new AppConflictException(`A skill with this name already exists: ${name}`);
+  }
+}

--- a/apps/api/src/modules/skills/dto/admin-skill-params.dto.ts
+++ b/apps/api/src/modules/skills/dto/admin-skill-params.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class SkillIdParamDto {
+  @IsUUID('4')
+  skillId!: string;
+}

--- a/apps/api/src/modules/skills/dto/admin-skill-prerequisite-params.dto.ts
+++ b/apps/api/src/modules/skills/dto/admin-skill-prerequisite-params.dto.ts
@@ -1,0 +1,11 @@
+import { IsUUID } from 'class-validator';
+
+export class SkillPrerequisiteListParamsDto {
+  @IsUUID('4')
+  skillId!: string;
+}
+
+export class SkillPrerequisiteParamsDto extends SkillPrerequisiteListParamsDto {
+  @IsUUID('4')
+  prereqSkillId!: string;
+}

--- a/apps/api/src/modules/skills/dto/admin-skill-prerequisite.dto.ts
+++ b/apps/api/src/modules/skills/dto/admin-skill-prerequisite.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class CreateSkillPrerequisiteDto {
+  @IsUUID('4')
+  prerequisiteSkillId!: string;
+}

--- a/apps/api/src/modules/skills/dto/admin-skill-query.dto.ts
+++ b/apps/api/src/modules/skills/dto/admin-skill-query.dto.ts
@@ -1,0 +1,34 @@
+import { RoleCategory } from '@repo/db/prisma/client';
+import { Transform, Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+const toTrimmedString = ({ value }): unknown => (typeof value === 'string' ? value.trim() : value);
+
+const toUppercaseString = ({ value }): unknown =>
+  typeof value === 'string' ? value.toUpperCase() : value;
+
+export class ListAdminSkillsQueryDto {
+  @IsOptional()
+  @Transform(toUppercaseString)
+  @IsEnum(RoleCategory)
+  roleCategory?: RoleCategory;
+
+  @IsOptional()
+  @Transform(toTrimmedString)
+  @IsString()
+  @MaxLength(200)
+  q?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  perPage?: number;
+}

--- a/apps/api/src/modules/skills/dto/admin-skill.dto.ts
+++ b/apps/api/src/modules/skills/dto/admin-skill.dto.ts
@@ -1,0 +1,78 @@
+import { RoleCategory } from '@repo/db/prisma/client';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+
+const isDefined = (_object: unknown, value: unknown): boolean => value !== undefined;
+
+const toTrimmedString = ({ value }): unknown => (typeof value === 'string' ? value.trim() : value);
+
+const toUppercaseString = ({ value }): unknown =>
+  typeof value === 'string' ? value.toUpperCase() : value;
+
+const estimatedHoursValidationOptions = {
+  allowInfinity: false,
+  allowNaN: false,
+  maxDecimalPlaces: 2,
+};
+
+export class CreateSkillDto {
+  @Transform(toTrimmedString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name!: string;
+
+  @IsOptional()
+  @Transform(toTrimmedString)
+  @IsString()
+  @MaxLength(2000)
+  description?: null | string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber(estimatedHoursValidationOptions)
+  @Min(0)
+  @Max(9999.99)
+  defaultEstimatedHours?: null | number;
+
+  @Transform(toUppercaseString)
+  @IsEnum(RoleCategory)
+  roleCategory!: RoleCategory;
+}
+
+export class UpdateSkillDto {
+  @ValidateIf(isDefined)
+  @Transform(toTrimmedString)
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name?: string;
+
+  @IsOptional()
+  @Transform(toTrimmedString)
+  @IsString()
+  @MaxLength(2000)
+  description?: null | string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber(estimatedHoursValidationOptions)
+  @Min(0)
+  @Max(9999.99)
+  defaultEstimatedHours?: null | number;
+
+  @ValidateIf(isDefined)
+  @Transform(toUppercaseString)
+  @IsEnum(RoleCategory)
+  roleCategory?: RoleCategory;
+}

--- a/apps/api/src/modules/skills/skills.module.ts
+++ b/apps/api/src/modules/skills/skills.module.ts
@@ -3,10 +3,12 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AdminSkillResourcesController } from './admin-skill-resources.controller';
 import { AdminSkillResourcesService } from './admin-skill-resources.service';
+import { AdminSkillsController } from './admin-skills.controller';
+import { AdminSkillsService } from './admin-skills.service';
 
 @Module({
-  controllers: [AdminSkillResourcesController],
+  controllers: [AdminSkillsController, AdminSkillResourcesController],
   imports: [PrismaModule],
-  providers: [AdminSkillResourcesService],
+  providers: [AdminSkillsService, AdminSkillResourcesService],
 })
 export class SkillsModule {}

--- a/apps/api/src/modules/skills/skills.module.ts
+++ b/apps/api/src/modules/skills/skills.module.ts
@@ -1,14 +1,20 @@
 import { Module } from '@nestjs/common';
 
 import { PrismaModule } from '../prisma/prisma.module';
+import { AdminSkillPrerequisitesController } from './admin-skill-prerequisites.controller';
+import { AdminSkillPrerequisitesService } from './admin-skill-prerequisites.service';
 import { AdminSkillResourcesController } from './admin-skill-resources.controller';
 import { AdminSkillResourcesService } from './admin-skill-resources.service';
 import { AdminSkillsController } from './admin-skills.controller';
 import { AdminSkillsService } from './admin-skills.service';
 
 @Module({
-  controllers: [AdminSkillsController, AdminSkillResourcesController],
+  controllers: [
+    AdminSkillsController,
+    AdminSkillPrerequisitesController,
+    AdminSkillResourcesController,
+  ],
   imports: [PrismaModule],
-  providers: [AdminSkillsService, AdminSkillResourcesService],
+  providers: [AdminSkillsService, AdminSkillPrerequisitesService, AdminSkillResourcesService],
 })
 export class SkillsModule {}

--- a/apps/api/src/modules/skills/types/admin-skill-prerequisite-response.types.ts
+++ b/apps/api/src/modules/skills/types/admin-skill-prerequisite-response.types.ts
@@ -1,0 +1,6 @@
+import type { SkillResponse } from './admin-skill-response.types';
+
+export interface SkillPrerequisiteListResponse {
+  prerequisites: SkillResponse[];
+  skillId: string;
+}

--- a/apps/api/src/modules/skills/types/admin-skill-response.types.ts
+++ b/apps/api/src/modules/skills/types/admin-skill-response.types.ts
@@ -1,0 +1,30 @@
+import type { RoleCategory } from '@repo/db/prisma/client';
+
+export interface SkillResponse {
+  createdAt: string;
+  defaultEstimatedHours: null | number;
+  description: null | string;
+  id: string;
+  name: string;
+  roleCategory: null | RoleCategory;
+  updatedAt: string;
+}
+
+export interface SkillPrerequisiteSummaryResponse {
+  name: string;
+  skillId: string;
+}
+
+export interface SkillDetailResponse extends SkillResponse {
+  prerequisites: SkillPrerequisiteSummaryResponse[];
+}
+
+export interface AdminSkillsListResponse {
+  data: SkillResponse[];
+  meta: {
+    page: number;
+    perPage: number;
+    total: number;
+    totalPages: number;
+  };
+}

--- a/apps/api/test/integration/admin-skill-prerequisites.integration-spec.ts
+++ b/apps/api/test/integration/admin-skill-prerequisites.integration-spec.ts
@@ -3,6 +3,8 @@ import request from 'supertest';
 
 import type { PrismaService } from '@/modules/prisma/prisma.service';
 
+import { ErrorCode } from '@/common/constants/error-codes';
+
 import { getCookieHeader } from './utils/cookies';
 import { seedUser, uniqueEmail } from './utils/database';
 import { setupIntegrationTest } from './utils/integration-test-context';
@@ -177,7 +179,7 @@ describe('Admin skill prerequisite management (integration)', () => {
       .expect(409);
 
     expect(duplicateResponse.body).toMatchObject({
-      code: 40900,
+      code: ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS,
     });
 
     await request(integration.app.getHttpServer())
@@ -185,10 +187,14 @@ describe('Admin skill prerequisite management (integration)', () => {
       .set('Cookie', cookie)
       .expect(204);
 
-    await request(integration.app.getHttpServer())
+    const missingEdgeResponse = await request(integration.app.getHttpServer())
       .delete(`/api/v1/admin/skills/${target.id}/prerequisites/${betaPrereq.id}`)
       .set('Cookie', cookie)
       .expect(404);
+
+    expect(missingEdgeResponse.body).toMatchObject({
+      code: ErrorCode.SKILL_PREREQUISITE_NOT_FOUND,
+    });
   });
 
   it('rejects self and transitive prerequisite cycles', async () => {
@@ -204,7 +210,7 @@ describe('Admin skill prerequisite management (integration)', () => {
       .expect(409);
 
     expect(selfResponse.body).toMatchObject({
-      code: 40900,
+      code: ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE,
     });
 
     await integration.prisma.skillPrerequisite.createMany({
@@ -227,7 +233,7 @@ describe('Admin skill prerequisite management (integration)', () => {
       .expect(409);
 
     expect(transitiveResponse.body).toMatchObject({
-      code: 40900,
+      code: ErrorCode.SKILL_PREREQUISITE_CYCLE,
     });
   });
 

--- a/apps/api/test/integration/admin-skill-prerequisites.integration-spec.ts
+++ b/apps/api/test/integration/admin-skill-prerequisites.integration-spec.ts
@@ -1,0 +1,266 @@
+import { RoleCategory, UserRole } from '@repo/db/prisma/client';
+import request from 'supertest';
+
+import type { PrismaService } from '@/modules/prisma/prisma.service';
+
+import { getCookieHeader } from './utils/cookies';
+import { seedUser, uniqueEmail } from './utils/database';
+import { setupIntegrationTest } from './utils/integration-test-context';
+
+type SkillBody = {
+  createdAt: string;
+  defaultEstimatedHours: null | number;
+  description: null | string;
+  id: string;
+  name: string;
+  roleCategory: null | RoleCategory;
+  updatedAt: string;
+};
+
+type SkillPrerequisiteListBody = {
+  prerequisites: SkillBody[];
+  skillId: string;
+};
+
+type ValidationBody = {
+  errors?: Record<string, unknown>;
+};
+
+const missingSkillId = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+
+const expectAnyArray = (): unknown[] => expect.any(Array) as unknown[];
+
+const uniqueName = (prefix: string): string =>
+  `${prefix} ${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const seedSkill = async (
+  prisma: PrismaService,
+  prefix: string,
+  data: {
+    defaultEstimatedHours?: number;
+    description?: null | string;
+    roleCategory?: RoleCategory;
+  } = {},
+) =>
+  await prisma.skill.create({
+    data: {
+      defaultEstimatedHours: data.defaultEstimatedHours,
+      description: Object.hasOwn(data, 'description') ? data.description : `${prefix} description`,
+      name: uniqueName(prefix),
+      roleCategory: data.roleCategory ?? RoleCategory.WEB_DEVELOPMENT,
+    },
+  });
+
+describe('Admin skill prerequisite management (integration)', () => {
+  const integration = setupIntegrationTest();
+
+  const loginAdmin = async (prefix: string): Promise<string> => {
+    const admin = await seedUser(integration.prisma, {
+      email: uniqueEmail(prefix),
+      role: UserRole.ADMIN,
+    });
+    const loginResponse = await integration.loginAs(admin.email);
+
+    return getCookieHeader(loginResponse, ['access_token']);
+  };
+
+  it('rejects unauthenticated and non-admin access to admin prerequisite routes', async () => {
+    const skill = await seedSkill(integration.prisma, 'Admin Prerequisite Auth Skill');
+
+    await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/skills/${skill.id}/prerequisites`)
+      .expect(401);
+
+    const user = await seedUser(integration.prisma, {
+      email: uniqueEmail('prerequisite-user'),
+    });
+    const loginResponse = await integration.loginAs(user.email);
+    const cookie = getCookieHeader(loginResponse, ['access_token']);
+
+    const forbiddenResponse = await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/skills/${skill.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .expect(403);
+
+    expect(forbiddenResponse.body).toMatchObject({
+      code: 40300,
+      message: 'Access denied',
+    });
+  });
+
+  it('validates prerequisite path and body UUID values', async () => {
+    const cookie = await loginAdmin('prerequisite-validation-admin');
+    const skill = await seedSkill(integration.prisma, 'Admin Prerequisite Validation Skill');
+
+    await request(integration.app.getHttpServer())
+      .get('/api/v1/admin/skills/not-a-uuid/prerequisites')
+      .set('Cookie', cookie)
+      .expect(400);
+
+    const bodyValidationResponse = await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${skill.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: 'not-a-uuid' })
+      .expect(400);
+    const bodyValidation = bodyValidationResponse.body as ValidationBody;
+
+    expect(bodyValidation.errors).toMatchObject({
+      prerequisiteSkillId: expectAnyArray(),
+    });
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${skill.id}/prerequisites/not-a-uuid`)
+      .set('Cookie', cookie)
+      .expect(400);
+  });
+
+  it('adds, lists, rejects duplicate, and deletes prerequisites through admin routes', async () => {
+    const cookie = await loginAdmin('prerequisite-crud-admin');
+    const target = await seedSkill(integration.prisma, 'Admin Prerequisite Target', {
+      description: 'Target skill',
+    });
+    const betaPrereq = await seedSkill(integration.prisma, 'ZZ Admin Prerequisite Beta', {
+      defaultEstimatedHours: 4.5,
+      description: 'Beta prerequisite',
+      roleCategory: RoleCategory.FRAMEWORKS,
+    });
+    const alphaPrereq = await seedSkill(integration.prisma, 'AA Admin Prerequisite Alpha', {
+      defaultEstimatedHours: 2,
+      description: null,
+      roleCategory: RoleCategory.DEVOPS,
+    });
+
+    await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${target.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: betaPrereq.id })
+      .expect(201);
+
+    await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${target.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: alphaPrereq.id })
+      .expect(201);
+
+    const listResponse = await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/skills/${target.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .expect(200);
+    const listBody = listResponse.body as SkillPrerequisiteListBody;
+
+    expect(listBody).toMatchObject({
+      prerequisites: [
+        {
+          defaultEstimatedHours: 2,
+          description: null,
+          id: alphaPrereq.id,
+          name: alphaPrereq.name,
+          roleCategory: RoleCategory.DEVOPS,
+        },
+        {
+          defaultEstimatedHours: 4.5,
+          description: 'Beta prerequisite',
+          id: betaPrereq.id,
+          name: betaPrereq.name,
+          roleCategory: RoleCategory.FRAMEWORKS,
+        },
+      ],
+      skillId: target.id,
+    });
+    expect(listBody.prerequisites[0]?.createdAt).toEqual(expect.any(String));
+    expect(listBody.prerequisites[0]?.updatedAt).toEqual(expect.any(String));
+
+    const duplicateResponse = await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${target.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: betaPrereq.id })
+      .expect(409);
+
+    expect(duplicateResponse.body).toMatchObject({
+      code: 40900,
+    });
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${target.id}/prerequisites/${betaPrereq.id}`)
+      .set('Cookie', cookie)
+      .expect(204);
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${target.id}/prerequisites/${betaPrereq.id}`)
+      .set('Cookie', cookie)
+      .expect(404);
+  });
+
+  it('rejects self and transitive prerequisite cycles', async () => {
+    const cookie = await loginAdmin('prerequisite-cycle-admin');
+    const skillA = await seedSkill(integration.prisma, 'Admin Cycle A');
+    const skillB = await seedSkill(integration.prisma, 'Admin Cycle B');
+    const skillC = await seedSkill(integration.prisma, 'Admin Cycle C');
+
+    const selfResponse = await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${skillA.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: skillA.id })
+      .expect(409);
+
+    expect(selfResponse.body).toMatchObject({
+      code: 40900,
+    });
+
+    await integration.prisma.skillPrerequisite.createMany({
+      data: [
+        {
+          prerequisiteSkillId: skillC.id,
+          skillId: skillB.id,
+        },
+        {
+          prerequisiteSkillId: skillA.id,
+          skillId: skillC.id,
+        },
+      ],
+    });
+
+    const transitiveResponse = await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${skillA.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: skillB.id })
+      .expect(409);
+
+    expect(transitiveResponse.body).toMatchObject({
+      code: 40900,
+    });
+  });
+
+  it('returns not found responses for missing target and prerequisite skills', async () => {
+    const cookie = await loginAdmin('prerequisite-missing-admin');
+    const target = await seedSkill(integration.prisma, 'Admin Missing Target');
+    const prerequisite = await seedSkill(integration.prisma, 'Admin Missing Prerequisite');
+
+    await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/skills/${missingSkillId}/prerequisites`)
+      .set('Cookie', cookie)
+      .expect(404);
+
+    await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${missingSkillId}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: prerequisite.id })
+      .expect(404);
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${missingSkillId}/prerequisites/${prerequisite.id}`)
+      .set('Cookie', cookie)
+      .expect(404);
+
+    await request(integration.app.getHttpServer())
+      .post(`/api/v1/admin/skills/${target.id}/prerequisites`)
+      .set('Cookie', cookie)
+      .send({ prerequisiteSkillId: missingSkillId })
+      .expect(404);
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${target.id}/prerequisites/${missingSkillId}`)
+      .set('Cookie', cookie)
+      .expect(404);
+  });
+});

--- a/apps/api/test/integration/admin-skills.integration-spec.ts
+++ b/apps/api/test/integration/admin-skills.integration-spec.ts
@@ -1,6 +1,8 @@
 import { NodeType, RoleCategory, UserRole } from '@repo/db/prisma/client';
 import request from 'supertest';
 
+import { ErrorCode } from '@/common/constants/error-codes';
+
 import { getCookieHeader } from './utils/cookies';
 import { seedUser, uniqueEmail } from './utils/database';
 import { setupIntegrationTest } from './utils/integration-test-context';
@@ -302,7 +304,7 @@ describe('Admin skill catalog management (integration)', () => {
       .expect(409);
 
     expect(createConflictResponse.body).toMatchObject({
-      code: 40900,
+      code: ErrorCode.SKILL_NAME_ALREADY_EXISTS,
     });
 
     const updateConflictResponse = await request(integration.app.getHttpServer())
@@ -314,7 +316,7 @@ describe('Admin skill catalog management (integration)', () => {
       .expect(409);
 
     expect(updateConflictResponse.body).toMatchObject({
-      code: 40900,
+      code: ErrorCode.SKILL_NAME_ALREADY_EXISTS,
     });
   });
 
@@ -382,7 +384,7 @@ describe('Admin skill catalog management (integration)', () => {
       .expect(409);
 
     expect(conflictResponse.body).toMatchObject({
-      code: 40900,
+      code: ErrorCode.SKILL_DELETE_REFERENCED,
     });
   });
 });

--- a/apps/api/test/integration/admin-skills.integration-spec.ts
+++ b/apps/api/test/integration/admin-skills.integration-spec.ts
@@ -1,0 +1,388 @@
+import { NodeType, RoleCategory, UserRole } from '@repo/db/prisma/client';
+import request from 'supertest';
+
+import { getCookieHeader } from './utils/cookies';
+import { seedUser, uniqueEmail } from './utils/database';
+import { setupIntegrationTest } from './utils/integration-test-context';
+
+type SkillIdBody = {
+  id: string;
+};
+
+type SkillBody = SkillIdBody & {
+  defaultEstimatedHours: null | number;
+  description: null | string;
+  name: string;
+  roleCategory: RoleCategory;
+};
+
+type SkillDetailBody = SkillBody & {
+  prerequisites: Array<{ name: string; skillId: string }>;
+};
+
+type SkillListBody = {
+  data: SkillBody[];
+  meta: {
+    page: number;
+    perPage: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+type ValidationBody = {
+  errors?: Record<string, unknown>;
+};
+
+const missingSkillId = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+
+const expectAnyArray = (): unknown[] => expect.any(Array) as unknown[];
+
+describe('Admin skill catalog management (integration)', () => {
+  const integration = setupIntegrationTest();
+
+  it('rejects unauthenticated and non-admin access to admin skill routes', async () => {
+    await request(integration.app.getHttpServer()).get('/api/v1/admin/skills').expect(401);
+
+    const user = await seedUser(integration.prisma, { email: uniqueEmail('skill-user') });
+    const loginResponse = await integration.loginAs(user.email);
+    const cookie = getCookieHeader(loginResponse, ['access_token']);
+
+    const forbiddenResponse = await request(integration.app.getHttpServer())
+      .get('/api/v1/admin/skills')
+      .set('Cookie', cookie)
+      .expect(403);
+
+    expect(forbiddenResponse.body).toMatchObject({
+      code: 40300,
+      message: 'Access denied',
+    });
+  });
+
+  it('creates, lists, gets, updates, and deletes skills through admin routes', async () => {
+    const admin = await seedUser(integration.prisma, {
+      email: uniqueEmail('skill-admin'),
+      role: UserRole.ADMIN,
+    });
+    const loginResponse = await integration.loginAs(admin.email);
+    const cookie = getCookieHeader(loginResponse, ['access_token']);
+    const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+    const alphaResponse = await request(integration.app.getHttpServer())
+      .post('/api/v1/admin/skills')
+      .set('Cookie', cookie)
+      .send({
+        defaultEstimatedHours: 4.5,
+        description: '  Learn token-based auth  ',
+        name: `  Admin Skill JWT Alpha ${suffix}  `,
+        roleCategory: 'web_development',
+      })
+      .expect(201);
+    const alpha = alphaResponse.body as SkillBody;
+
+    expect(alphaResponse.body).toMatchObject({
+      defaultEstimatedHours: 4.5,
+      description: 'Learn token-based auth',
+      name: `Admin Skill JWT Alpha ${suffix}`,
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    });
+
+    const betaResponse = await request(integration.app.getHttpServer())
+      .post('/api/v1/admin/skills')
+      .set('Cookie', cookie)
+      .send({
+        defaultEstimatedHours: null,
+        description: null,
+        name: `Admin Skill JWT Beta ${suffix}`,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      })
+      .expect(201);
+    const beta = betaResponse.body as SkillBody;
+
+    await request(integration.app.getHttpServer())
+      .post('/api/v1/admin/skills')
+      .set('Cookie', cookie)
+      .send({
+        name: `Admin Skill Docker ${suffix}`,
+        roleCategory: RoleCategory.DEVOPS,
+      })
+      .expect(201);
+
+    const listResponse = await request(integration.app.getHttpServer())
+      .get('/api/v1/admin/skills')
+      .query({
+        page: 1,
+        perPage: 1,
+        q: 'jwt',
+        roleCategory: 'web_development',
+      })
+      .set('Cookie', cookie)
+      .expect(200);
+    const listBody = listResponse.body as SkillListBody;
+
+    expect(listBody).toMatchObject({
+      meta: {
+        page: 1,
+        perPage: 1,
+        total: 2,
+        totalPages: 2,
+      },
+    });
+    expect(listBody.data).toHaveLength(1);
+    expect(listBody.data[0]).toMatchObject({
+      id: alpha.id,
+      name: `Admin Skill JWT Alpha ${suffix}`,
+    });
+
+    const betaPrerequisite = await integration.prisma.skill.create({
+      data: {
+        name: `ZZ Admin Skill Prerequisite ${suffix}`,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      },
+    });
+    const alphaPrerequisite = await integration.prisma.skill.create({
+      data: {
+        name: `AA Admin Skill Prerequisite ${suffix}`,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      },
+    });
+
+    await integration.prisma.skillPrerequisite.createMany({
+      data: [
+        {
+          prerequisiteSkillId: betaPrerequisite.id,
+          skillId: alpha.id,
+        },
+        {
+          prerequisiteSkillId: alphaPrerequisite.id,
+          skillId: alpha.id,
+        },
+      ],
+    });
+
+    const detailResponse = await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/skills/${alpha.id}`)
+      .set('Cookie', cookie)
+      .expect(200);
+    const detailBody = detailResponse.body as SkillDetailBody;
+
+    expect(detailBody).toMatchObject({
+      id: alpha.id,
+      prerequisites: [
+        {
+          name: alphaPrerequisite.name,
+          skillId: alphaPrerequisite.id,
+        },
+        {
+          name: betaPrerequisite.name,
+          skillId: betaPrerequisite.id,
+        },
+      ],
+    });
+
+    const updateResponse = await request(integration.app.getHttpServer())
+      .put(`/api/v1/admin/skills/${alpha.id}`)
+      .set('Cookie', cookie)
+      .send({
+        defaultEstimatedHours: null,
+        description: null,
+        name: `Admin Skill JWT Updated ${suffix}`,
+        roleCategory: 'devops',
+      })
+      .expect(200);
+
+    expect(updateResponse.body).toMatchObject({
+      defaultEstimatedHours: null,
+      description: null,
+      id: alpha.id,
+      name: `Admin Skill JWT Updated ${suffix}`,
+      roleCategory: RoleCategory.DEVOPS,
+    });
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${beta.id}`)
+      .set('Cookie', cookie)
+      .expect(204);
+
+    await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/skills/${beta.id}`)
+      .set('Cookie', cookie)
+      .expect(404);
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${alpha.id}`)
+      .set('Cookie', cookie)
+      .expect(204);
+  });
+
+  it('validates skill payloads, query params, and path params', async () => {
+    const admin = await seedUser(integration.prisma, {
+      email: uniqueEmail('skill-validation-admin'),
+      role: UserRole.ADMIN,
+    });
+    const loginResponse = await integration.loginAs(admin.email);
+    const cookie = getCookieHeader(loginResponse, ['access_token']);
+
+    await request(integration.app.getHttpServer())
+      .get('/api/v1/admin/skills/not-a-uuid')
+      .set('Cookie', cookie)
+      .expect(400);
+
+    await request(integration.app.getHttpServer())
+      .get('/api/v1/admin/skills')
+      .query({ perPage: 101 })
+      .set('Cookie', cookie)
+      .expect(400);
+
+    const emptyNameResponse = await request(integration.app.getHttpServer())
+      .post('/api/v1/admin/skills')
+      .set('Cookie', cookie)
+      .send({
+        name: '   ',
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      })
+      .expect(400);
+    const emptyNameBody = emptyNameResponse.body as ValidationBody;
+
+    expect(emptyNameBody.errors).toMatchObject({
+      name: expectAnyArray(),
+    });
+
+    const invalidPayloadResponse = await request(integration.app.getHttpServer())
+      .post('/api/v1/admin/skills')
+      .set('Cookie', cookie)
+      .send({
+        defaultEstimatedHours: -1,
+        extra: 'not allowed',
+        name: 'Invalid Skill',
+        roleCategory: 'not-a-category',
+      })
+      .expect(400);
+    const invalidPayloadBody = invalidPayloadResponse.body as ValidationBody;
+
+    expect(invalidPayloadResponse.body).toMatchObject({
+      code: 40001,
+      message: 'Validation failed',
+    });
+    expect(invalidPayloadBody.errors).toMatchObject({
+      defaultEstimatedHours: expectAnyArray(),
+      extra: expectAnyArray(),
+      roleCategory: expectAnyArray(),
+    });
+  });
+
+  it('returns conflict responses for duplicate skill names', async () => {
+    const admin = await seedUser(integration.prisma, {
+      email: uniqueEmail('skill-conflict-admin'),
+      role: UserRole.ADMIN,
+    });
+    const loginResponse = await integration.loginAs(admin.email);
+    const cookie = getCookieHeader(loginResponse, ['access_token']);
+    const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const existing = await integration.prisma.skill.create({
+      data: {
+        name: `Admin Skill Unique ${suffix}`,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      },
+    });
+    const other = await integration.prisma.skill.create({
+      data: {
+        name: `Admin Skill Other ${suffix}`,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      },
+    });
+
+    const createConflictResponse = await request(integration.app.getHttpServer())
+      .post('/api/v1/admin/skills')
+      .set('Cookie', cookie)
+      .send({
+        name: existing.name,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      })
+      .expect(409);
+
+    expect(createConflictResponse.body).toMatchObject({
+      code: 40900,
+    });
+
+    const updateConflictResponse = await request(integration.app.getHttpServer())
+      .put(`/api/v1/admin/skills/${other.id}`)
+      .set('Cookie', cookie)
+      .send({
+        name: existing.name,
+      })
+      .expect(409);
+
+    expect(updateConflictResponse.body).toMatchObject({
+      code: 40900,
+    });
+  });
+
+  it('returns not found responses for missing skills', async () => {
+    const admin = await seedUser(integration.prisma, {
+      email: uniqueEmail('skill-missing-admin'),
+      role: UserRole.ADMIN,
+    });
+    const loginResponse = await integration.loginAs(admin.email);
+    const cookie = getCookieHeader(loginResponse, ['access_token']);
+
+    await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/skills/${missingSkillId}`)
+      .set('Cookie', cookie)
+      .expect(404);
+
+    await request(integration.app.getHttpServer())
+      .put(`/api/v1/admin/skills/${missingSkillId}`)
+      .set('Cookie', cookie)
+      .send({ name: 'Missing Skill' })
+      .expect(404);
+
+    await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${missingSkillId}`)
+      .set('Cookie', cookie)
+      .expect(404);
+  });
+
+  it('blocks deleting skills referenced by roadmap or template nodes', async () => {
+    const admin = await seedUser(integration.prisma, {
+      email: uniqueEmail('skill-reference-admin'),
+      role: UserRole.ADMIN,
+    });
+    const loginResponse = await integration.loginAs(admin.email);
+    const cookie = getCookieHeader(loginResponse, ['access_token']);
+    const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const skill = await integration.prisma.skill.create({
+      data: {
+        name: `Admin Skill Referenced ${suffix}`,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      },
+    });
+    const template = await integration.prisma.roadmap.create({
+      data: {
+        isTemplate: true,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+        title: `Referenced Template ${suffix}`,
+      },
+    });
+
+    await integration.prisma.roadmapNode.create({
+      data: {
+        name: `Referenced Skill Node ${suffix}`,
+        nodeType: NodeType.REQUIRED,
+        posX: 0,
+        posY: 0,
+        roadmapId: template.id,
+        skillId: skill.id,
+      },
+    });
+
+    const conflictResponse = await request(integration.app.getHttpServer())
+      .delete(`/api/v1/admin/skills/${skill.id}`)
+      .set('Cookie', cookie)
+      .expect(409);
+
+    expect(conflictResponse.body).toMatchObject({
+      code: 40900,
+    });
+  });
+});

--- a/apps/api/test/unit/skills/admin-skill-prerequisites.controller.spec.ts
+++ b/apps/api/test/unit/skills/admin-skill-prerequisites.controller.spec.ts
@@ -1,0 +1,84 @@
+import 'reflect-metadata';
+
+import type { TestingModule } from '@nestjs/testing';
+
+import { Test } from '@nestjs/testing';
+import { UserRole } from '@repo/db/prisma/client';
+
+import { ROLES_KEY } from '@/common/decorators/roles.decorator';
+import { AdminSkillPrerequisitesController } from '@/modules/skills/admin-skill-prerequisites.controller';
+import { AdminSkillPrerequisitesService } from '@/modules/skills/admin-skill-prerequisites.service';
+
+describe('AdminSkillPrerequisitesController', () => {
+  const skillId = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+  const prereqSkillId = '8b5f0d95-8f4a-4ee8-a9f4-0fa0b79f533f';
+
+  const mockAdminSkillPrerequisitesService = {
+    createPrerequisite: jest.fn(),
+    deletePrerequisite: jest.fn(),
+    listPrerequisites: jest.fn(),
+  };
+
+  let controller: AdminSkillPrerequisitesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminSkillPrerequisitesController],
+      providers: [
+        {
+          provide: AdminSkillPrerequisitesService,
+          useValue: mockAdminSkillPrerequisitesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AdminSkillPrerequisitesController>(AdminSkillPrerequisitesController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires admin role metadata at the controller level', () => {
+    expect(Reflect.getMetadata(ROLES_KEY, AdminSkillPrerequisitesController)).toEqual([
+      UserRole.ADMIN,
+    ]);
+  });
+
+  it('delegates prerequisite listing with path params', async () => {
+    const response = { prerequisites: [], skillId };
+
+    mockAdminSkillPrerequisitesService.listPrerequisites.mockResolvedValue(response);
+
+    const result = await controller.list({ skillId });
+
+    expect(mockAdminSkillPrerequisitesService.listPrerequisites).toHaveBeenCalledWith(skillId);
+    expect(result).toEqual(response);
+  });
+
+  it('delegates prerequisite creation with path params and body dto', async () => {
+    const dto = { prerequisiteSkillId: prereqSkillId };
+
+    mockAdminSkillPrerequisitesService.createPrerequisite.mockResolvedValue(undefined);
+
+    const result = await controller.create({ skillId }, dto);
+
+    expect(mockAdminSkillPrerequisitesService.createPrerequisite).toHaveBeenCalledWith(
+      skillId,
+      dto,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('delegates prerequisite deletion and returns no body', async () => {
+    mockAdminSkillPrerequisitesService.deletePrerequisite.mockResolvedValue(undefined);
+
+    const result = await controller.remove({ prereqSkillId, skillId });
+
+    expect(mockAdminSkillPrerequisitesService.deletePrerequisite).toHaveBeenCalledWith(
+      skillId,
+      prereqSkillId,
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/api/test/unit/skills/admin-skill-prerequisites.service.spec.ts
+++ b/apps/api/test/unit/skills/admin-skill-prerequisites.service.spec.ts
@@ -1,0 +1,386 @@
+import type { TestingModule } from '@nestjs/testing';
+
+import { HttpException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { RoleCategory } from '@repo/db/prisma/client';
+import { PrismaClientKnownRequestError } from '@repo/db/prisma/internal/prismaNamespace';
+
+import { ErrorCode } from '@/common/constants/error-codes';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+import { AdminSkillPrerequisitesService } from '@/modules/skills/admin-skill-prerequisites.service';
+
+type AsyncMock<TResult = unknown, TArgs extends unknown[] = unknown[]> = jest.Mock<
+  Promise<TResult>,
+  TArgs
+>;
+
+type DecimalLike = {
+  toNumber?: () => number;
+  toString: () => string;
+};
+
+interface SkillRecord {
+  createdAt: Date;
+  defaultEstimatedHours: DecimalLike | null | number;
+  description: null | string;
+  id: string;
+  name: string;
+  roleCategory: null | RoleCategory;
+  updatedAt: Date;
+}
+
+interface SkillPrerequisiteRecord {
+  prerequisiteSkill: SkillRecord;
+}
+
+interface EdgeRecord {
+  prerequisiteSkillId: string;
+  skillId: string;
+}
+
+interface TxMock {
+  skill: {
+    findUnique: AsyncMock<{ id: string } | null>;
+  };
+  skillPrerequisite: {
+    create: AsyncMock<EdgeRecord>;
+    findMany: AsyncMock<Array<Pick<EdgeRecord, 'prerequisiteSkillId'>>>;
+    findUnique: AsyncMock<EdgeRecord | null>;
+  };
+}
+
+interface AdminSkillPrerequisitesPrismaMock {
+  $transaction: AsyncMock<unknown, [unknown]>;
+  skill: {
+    findUnique: AsyncMock<{ id: string } | null>;
+  };
+  skillPrerequisite: {
+    deleteMany: AsyncMock<{ count: number }>;
+    findMany: AsyncMock<SkillPrerequisiteRecord[]>;
+  };
+}
+
+const skillId = 'skill-1';
+const prereqSkillId = 'skill-2';
+const transitiveSkillId = 'skill-3';
+
+const expectExceptionCode = async (promise: Promise<unknown>, code: ErrorCode): Promise<void> => {
+  let caught: unknown;
+
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+
+  if (!(caught instanceof HttpException)) {
+    throw new Error('Expected promise to reject with an HttpException');
+  }
+
+  expect(caught.getResponse()).toMatchObject({ code });
+};
+
+const makeDecimal = (value: number): DecimalLike => ({
+  toNumber: () => value,
+  toString: () => String(value),
+});
+
+const makeSkill = (overrides: Partial<SkillRecord> = {}): SkillRecord => ({
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  defaultEstimatedHours: makeDecimal(6.5),
+  description: 'Skill description',
+  id: prereqSkillId,
+  name: 'React Fundamentals',
+  roleCategory: RoleCategory.FRAMEWORKS,
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  ...overrides,
+});
+
+const makeDuplicateEdgeError = (): PrismaClientKnownRequestError =>
+  new PrismaClientKnownRequestError('Unique failed', {
+    clientVersion: 'test',
+    code: 'P2002',
+    meta: { target: ['skillId', 'prerequisiteSkillId'] },
+  });
+
+const makeTxMock = (): TxMock => ({
+  skill: {
+    findUnique: jest.fn<Promise<{ id: string } | null>, unknown[]>(),
+  },
+  skillPrerequisite: {
+    create: jest.fn<Promise<EdgeRecord>, unknown[]>(),
+    findMany: jest.fn<Promise<Array<Pick<EdgeRecord, 'prerequisiteSkillId'>>>, unknown[]>(),
+    findUnique: jest.fn<Promise<EdgeRecord | null>, unknown[]>(),
+  },
+});
+
+const createPrismaMock = (txMock: TxMock): AdminSkillPrerequisitesPrismaMock => ({
+  $transaction: jest.fn<Promise<unknown>, [unknown]>().mockImplementation((input) => {
+    const callback = input as (tx: TxMock) => unknown;
+
+    return Promise.resolve(callback(txMock));
+  }),
+  skill: {
+    findUnique: jest.fn<Promise<{ id: string } | null>, unknown[]>(),
+  },
+  skillPrerequisite: {
+    deleteMany: jest.fn<Promise<{ count: number }>, unknown[]>(),
+    findMany: jest.fn<Promise<SkillPrerequisiteRecord[]>, unknown[]>(),
+  },
+});
+
+const expectAnyObject = (): object => expect.any(Object) as object;
+
+describe('AdminSkillPrerequisitesService', () => {
+  let prisma: AdminSkillPrerequisitesPrismaMock;
+  let service: AdminSkillPrerequisitesService;
+  let txMock: TxMock;
+
+  beforeEach(async () => {
+    txMock = makeTxMock();
+    const prismaMock = createPrismaMock(txMock);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminSkillPrerequisitesService,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+      ],
+    }).compile();
+
+    prisma = prismaMock;
+    service = module.get<AdminSkillPrerequisitesService>(AdminSkillPrerequisitesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists prerequisites ordered by prerequisite skill name and id with full skill responses', async () => {
+    const alpha = makeSkill({
+      defaultEstimatedHours: 2,
+      id: 'skill-alpha',
+      name: 'Alpha Basics',
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    });
+    const beta = makeSkill({
+      defaultEstimatedHours: null,
+      description: null,
+      id: 'skill-beta',
+      name: 'Beta Basics',
+      roleCategory: null,
+    });
+
+    prisma.skill.findUnique.mockResolvedValue({ id: skillId });
+    prisma.skillPrerequisite.findMany.mockResolvedValue([
+      { prerequisiteSkill: alpha },
+      { prerequisiteSkill: beta },
+    ]);
+
+    const result = await service.listPrerequisites(skillId);
+
+    expect(prisma.skillPrerequisite.findMany).toHaveBeenCalledWith({
+      orderBy: [{ prerequisiteSkill: { name: 'asc' } }, { prerequisiteSkillId: 'asc' }],
+      select: {
+        prerequisiteSkill: {
+          select: expectAnyObject(),
+        },
+      },
+      where: { skillId },
+    });
+    expect(result).toEqual({
+      prerequisites: [
+        {
+          createdAt: '2026-01-01T00:00:00.000Z',
+          defaultEstimatedHours: 2,
+          description: 'Skill description',
+          id: 'skill-alpha',
+          name: 'Alpha Basics',
+          roleCategory: RoleCategory.WEB_DEVELOPMENT,
+          updatedAt: '2026-01-02T00:00:00.000Z',
+        },
+        {
+          createdAt: '2026-01-01T00:00:00.000Z',
+          defaultEstimatedHours: null,
+          description: null,
+          id: 'skill-beta',
+          name: 'Beta Basics',
+          roleCategory: null,
+          updatedAt: '2026-01-02T00:00:00.000Z',
+        },
+      ],
+      skillId,
+    });
+  });
+
+  it('throws SkillNotFoundException when listing prerequisites for a missing target skill', async () => {
+    prisma.skill.findUnique.mockResolvedValue(null);
+
+    await expectExceptionCode(service.listPrerequisites(skillId), ErrorCode.SKILL_NOT_FOUND);
+
+    expect(prisma.skillPrerequisite.findMany).not.toHaveBeenCalled();
+  });
+
+  it('creates a prerequisite edge after both skills exist', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.skillPrerequisite.findUnique.mockResolvedValue(null);
+    txMock.skillPrerequisite.findMany.mockResolvedValue([]);
+    txMock.skillPrerequisite.create.mockResolvedValue({
+      prerequisiteSkillId: prereqSkillId,
+      skillId,
+    });
+
+    await expect(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
+    ).resolves.toBeUndefined();
+
+    expect(txMock.skill.findUnique).toHaveBeenCalledTimes(2);
+    expect(txMock.skillPrerequisite.create).toHaveBeenCalledWith({
+      data: {
+        prerequisiteSkillId: prereqSkillId,
+        skillId,
+      },
+      select: {
+        prerequisiteSkillId: true,
+        skillId: true,
+      },
+    });
+  });
+
+  it('throws SkillNotFoundException when creating for a missing target skill', async () => {
+    txMock.skill.findUnique.mockResolvedValueOnce(null);
+
+    await expectExceptionCode(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
+      ErrorCode.SKILL_NOT_FOUND,
+    );
+
+    expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
+  });
+
+  it('throws SkillNotFoundException when creating with a missing prerequisite skill', async () => {
+    txMock.skill.findUnique.mockResolvedValueOnce({ id: skillId }).mockResolvedValueOnce(null);
+
+    await expectExceptionCode(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
+      ErrorCode.SKILL_NOT_FOUND,
+    );
+
+    expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate prerequisite edges', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.skillPrerequisite.findUnique.mockResolvedValue({
+      prerequisiteSkillId: prereqSkillId,
+      skillId,
+    });
+
+    await expectExceptionCode(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
+      ErrorCode.CONFLICT,
+    );
+
+    expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
+  });
+
+  it('maps duplicate edge races from Prisma to conflict responses', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.skillPrerequisite.findUnique.mockResolvedValue(null);
+    txMock.skillPrerequisite.findMany.mockResolvedValue([]);
+    txMock.skillPrerequisite.create.mockRejectedValue(makeDuplicateEdgeError());
+
+    await expectExceptionCode(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
+      ErrorCode.CONFLICT,
+    );
+  });
+
+  it('rejects self-prerequisites', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+
+    await expectExceptionCode(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: skillId }),
+      ErrorCode.CONFLICT,
+    );
+
+    expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct cycles', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.skillPrerequisite.findUnique.mockResolvedValue(null);
+    txMock.skillPrerequisite.findMany.mockResolvedValue([{ prerequisiteSkillId: skillId }]);
+
+    await expectExceptionCode(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
+      ErrorCode.CONFLICT,
+    );
+
+    expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects transitive cycles', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.skillPrerequisite.findUnique.mockResolvedValue(null);
+    txMock.skillPrerequisite.findMany
+      .mockResolvedValueOnce([{ prerequisiteSkillId: transitiveSkillId }])
+      .mockResolvedValueOnce([{ prerequisiteSkillId: skillId }]);
+
+    await expectExceptionCode(
+      service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
+      ErrorCode.CONFLICT,
+    );
+
+    expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
+  });
+
+  it('deletes an existing prerequisite edge', async () => {
+    prisma.skill.findUnique.mockResolvedValue({ id: skillId });
+    prisma.skillPrerequisite.deleteMany.mockResolvedValue({ count: 1 });
+
+    await expect(service.deletePrerequisite(skillId, prereqSkillId)).resolves.toBeUndefined();
+
+    expect(prisma.skill.findUnique).toHaveBeenCalledTimes(2);
+    expect(prisma.skillPrerequisite.deleteMany).toHaveBeenCalledWith({
+      where: {
+        prerequisiteSkillId: prereqSkillId,
+        skillId,
+      },
+    });
+  });
+
+  it('throws AppNotFoundException when deleting a missing prerequisite edge', async () => {
+    prisma.skill.findUnique.mockResolvedValue({ id: skillId });
+    prisma.skillPrerequisite.deleteMany.mockResolvedValue({ count: 0 });
+
+    await expectExceptionCode(
+      service.deletePrerequisite(skillId, prereqSkillId),
+      ErrorCode.NOT_FOUND,
+    );
+  });
+
+  it('throws SkillNotFoundException when deleting with a missing target skill', async () => {
+    prisma.skill.findUnique.mockResolvedValueOnce(null);
+
+    await expectExceptionCode(
+      service.deletePrerequisite(skillId, prereqSkillId),
+      ErrorCode.SKILL_NOT_FOUND,
+    );
+
+    expect(prisma.skillPrerequisite.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('throws SkillNotFoundException when deleting with a missing prerequisite skill', async () => {
+    prisma.skill.findUnique.mockResolvedValueOnce({ id: skillId }).mockResolvedValueOnce(null);
+
+    await expectExceptionCode(
+      service.deletePrerequisite(skillId, prereqSkillId),
+      ErrorCode.SKILL_NOT_FOUND,
+    );
+
+    expect(prisma.skillPrerequisite.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/unit/skills/admin-skill-prerequisites.service.spec.ts
+++ b/apps/api/test/unit/skills/admin-skill-prerequisites.service.spec.ts
@@ -280,7 +280,7 @@ describe('AdminSkillPrerequisitesService', () => {
 
     await expectExceptionCode(
       service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
-      ErrorCode.CONFLICT,
+      ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS,
     );
 
     expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
@@ -294,7 +294,7 @@ describe('AdminSkillPrerequisitesService', () => {
 
     await expectExceptionCode(
       service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
-      ErrorCode.CONFLICT,
+      ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS,
     );
   });
 
@@ -303,7 +303,7 @@ describe('AdminSkillPrerequisitesService', () => {
 
     await expectExceptionCode(
       service.createPrerequisite(skillId, { prerequisiteSkillId: skillId }),
-      ErrorCode.CONFLICT,
+      ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE,
     );
 
     expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
@@ -316,7 +316,7 @@ describe('AdminSkillPrerequisitesService', () => {
 
     await expectExceptionCode(
       service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
-      ErrorCode.CONFLICT,
+      ErrorCode.SKILL_PREREQUISITE_CYCLE,
     );
 
     expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
@@ -331,7 +331,7 @@ describe('AdminSkillPrerequisitesService', () => {
 
     await expectExceptionCode(
       service.createPrerequisite(skillId, { prerequisiteSkillId: prereqSkillId }),
-      ErrorCode.CONFLICT,
+      ErrorCode.SKILL_PREREQUISITE_CYCLE,
     );
 
     expect(txMock.skillPrerequisite.create).not.toHaveBeenCalled();
@@ -352,13 +352,13 @@ describe('AdminSkillPrerequisitesService', () => {
     });
   });
 
-  it('throws AppNotFoundException when deleting a missing prerequisite edge', async () => {
+  it('throws SkillPrerequisiteNotFoundException when deleting a missing prerequisite edge', async () => {
     prisma.skill.findUnique.mockResolvedValue({ id: skillId });
     prisma.skillPrerequisite.deleteMany.mockResolvedValue({ count: 0 });
 
     await expectExceptionCode(
       service.deletePrerequisite(skillId, prereqSkillId),
-      ErrorCode.NOT_FOUND,
+      ErrorCode.SKILL_PREREQUISITE_NOT_FOUND,
     );
   });
 

--- a/apps/api/test/unit/skills/admin-skills.controller.spec.ts
+++ b/apps/api/test/unit/skills/admin-skills.controller.spec.ts
@@ -1,0 +1,112 @@
+import 'reflect-metadata';
+
+import type { TestingModule } from '@nestjs/testing';
+
+import { Test } from '@nestjs/testing';
+import { RoleCategory, UserRole } from '@repo/db/prisma/client';
+
+import { ROLES_KEY } from '@/common/decorators/roles.decorator';
+import { AdminSkillsController } from '@/modules/skills/admin-skills.controller';
+import { AdminSkillsService } from '@/modules/skills/admin-skills.service';
+
+describe('AdminSkillsController', () => {
+  const skillId = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+
+  const mockAdminSkillsService = {
+    createSkill: jest.fn(),
+    deleteSkill: jest.fn(),
+    getSkill: jest.fn(),
+    listSkills: jest.fn(),
+    updateSkill: jest.fn(),
+  };
+
+  let controller: AdminSkillsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminSkillsController],
+      providers: [
+        {
+          provide: AdminSkillsService,
+          useValue: mockAdminSkillsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AdminSkillsController>(AdminSkillsController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requires admin role metadata at the controller level', () => {
+    expect(Reflect.getMetadata(ROLES_KEY, AdminSkillsController)).toEqual([UserRole.ADMIN]);
+  });
+
+  it('delegates skill listing with query params', async () => {
+    const query = {
+      page: 2,
+      perPage: 10,
+      q: 'react',
+      roleCategory: RoleCategory.FRAMEWORKS,
+    };
+    const response = { data: [], meta: { page: 2, perPage: 10, total: 0, totalPages: 0 } };
+
+    mockAdminSkillsService.listSkills.mockResolvedValue(response);
+
+    const result = await controller.list(query);
+
+    expect(mockAdminSkillsService.listSkills).toHaveBeenCalledWith(query);
+    expect(result).toEqual(response);
+  });
+
+  it('delegates skill creation with body dto', async () => {
+    const dto = {
+      defaultEstimatedHours: 4,
+      description: 'JWT basics',
+      name: 'JWT Authentication',
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    };
+    const response = { id: skillId };
+
+    mockAdminSkillsService.createSkill.mockResolvedValue(response);
+
+    const result = await controller.create(dto);
+
+    expect(mockAdminSkillsService.createSkill).toHaveBeenCalledWith(dto);
+    expect(result).toEqual(response);
+  });
+
+  it('delegates skill detail lookup with path params', async () => {
+    const response = { id: skillId, prerequisites: [] };
+
+    mockAdminSkillsService.getSkill.mockResolvedValue(response);
+
+    const result = await controller.get({ skillId });
+
+    expect(mockAdminSkillsService.getSkill).toHaveBeenCalledWith(skillId);
+    expect(result).toEqual(response);
+  });
+
+  it('delegates skill updates with path params and body dto', async () => {
+    const dto = { description: null, name: 'Updated Skill' };
+    const response = { id: skillId, name: dto.name };
+
+    mockAdminSkillsService.updateSkill.mockResolvedValue(response);
+
+    const result = await controller.update({ skillId }, dto);
+
+    expect(mockAdminSkillsService.updateSkill).toHaveBeenCalledWith(skillId, dto);
+    expect(result).toEqual(response);
+  });
+
+  it('delegates skill deletion and returns no body', async () => {
+    mockAdminSkillsService.deleteSkill.mockResolvedValue(undefined);
+
+    const result = await controller.remove({ skillId });
+
+    expect(mockAdminSkillsService.deleteSkill).toHaveBeenCalledWith(skillId);
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/api/test/unit/skills/admin-skills.service.spec.ts
+++ b/apps/api/test/unit/skills/admin-skills.service.spec.ts
@@ -1,0 +1,398 @@
+import type { TestingModule } from '@nestjs/testing';
+
+import { HttpException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { RoleCategory } from '@repo/db/prisma/client';
+import { PrismaClientKnownRequestError } from '@repo/db/prisma/internal/prismaNamespace';
+
+import { ErrorCode } from '@/common/constants/error-codes';
+import { PrismaService } from '@/modules/prisma/prisma.service';
+import { AdminSkillsService } from '@/modules/skills/admin-skills.service';
+
+type AsyncMock<TResult = unknown, TArgs extends unknown[] = unknown[]> = jest.Mock<
+  Promise<TResult>,
+  TArgs
+>;
+
+type DecimalLike = {
+  toNumber?: () => number;
+  toString: () => string;
+};
+
+interface SkillRecord {
+  createdAt: Date;
+  defaultEstimatedHours: DecimalLike | null | number;
+  description: null | string;
+  id: string;
+  name: string;
+  roleCategory: null | RoleCategory;
+  updatedAt: Date;
+}
+
+interface SkillDetailRecord extends SkillRecord {
+  prerequisites: Array<{
+    prerequisiteSkill: {
+      name: string;
+    };
+    prerequisiteSkillId: string;
+  }>;
+}
+
+interface AdminSkillsPrismaMock {
+  $transaction: AsyncMock<unknown, [unknown]>;
+  roadmapNode: {
+    findFirst: AsyncMock<{ id: string } | null>;
+  };
+  skill: {
+    count: AsyncMock<number>;
+    create: AsyncMock<SkillRecord>;
+    delete: AsyncMock<{ id: string }>;
+    findMany: AsyncMock<SkillRecord[]>;
+    findUnique: AsyncMock<SkillDetailRecord | SkillRecord | { id: string } | null>;
+    update: AsyncMock<SkillRecord>;
+  };
+}
+
+const skillId = 'skill-1';
+
+const expectExceptionCode = async (promise: Promise<unknown>, code: ErrorCode): Promise<void> => {
+  let caught: unknown;
+
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+
+  if (!(caught instanceof HttpException)) {
+    throw new Error('Expected promise to reject with an HttpException');
+  }
+
+  expect(caught.getResponse()).toMatchObject({ code });
+};
+
+const makeDecimal = (value: number): DecimalLike => ({
+  toNumber: () => value,
+  toString: () => String(value),
+});
+
+const makeSkill = (overrides: Partial<SkillRecord> = {}): SkillRecord => ({
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  defaultEstimatedHours: makeDecimal(6.5),
+  description: 'Skill description',
+  id: skillId,
+  name: 'React Fundamentals',
+  roleCategory: RoleCategory.FRAMEWORKS,
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  ...overrides,
+});
+
+const makeUniqueNameError = (): PrismaClientKnownRequestError =>
+  new PrismaClientKnownRequestError('Unique failed', {
+    clientVersion: 'test',
+    code: 'P2002',
+    meta: { target: ['name'] },
+  });
+
+const createPrismaMock = (): AdminSkillsPrismaMock => ({
+  $transaction: jest.fn<Promise<unknown>, [unknown]>().mockImplementation((input) => {
+    if (Array.isArray(input)) {
+      return Promise.all(input);
+    }
+
+    return Promise.resolve(input);
+  }),
+  roadmapNode: {
+    findFirst: jest.fn<Promise<{ id: string } | null>, unknown[]>(),
+  },
+  skill: {
+    count: jest.fn<Promise<number>, unknown[]>(),
+    create: jest.fn<Promise<SkillRecord>, unknown[]>(),
+    delete: jest.fn<Promise<{ id: string }>, unknown[]>(),
+    findMany: jest.fn<Promise<SkillRecord[]>, unknown[]>(),
+    findUnique: jest.fn<
+      Promise<SkillDetailRecord | SkillRecord | { id: string } | null>,
+      unknown[]
+    >(),
+    update: jest.fn<Promise<SkillRecord>, unknown[]>(),
+  },
+});
+
+const expectAnyObject = (): object => expect.any(Object) as object;
+
+describe('AdminSkillsService', () => {
+  let prisma: AdminSkillsPrismaMock;
+  let service: AdminSkillsService;
+
+  beforeEach(async () => {
+    const prismaMock = createPrismaMock();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminSkillsService,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+      ],
+    }).compile();
+
+    prisma = prismaMock;
+    service = module.get<AdminSkillsService>(AdminSkillsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists skills with pagination, role category filtering, and case-insensitive search', async () => {
+    const skill = makeSkill();
+
+    prisma.skill.findMany.mockResolvedValue([skill]);
+    prisma.skill.count.mockResolvedValue(21);
+
+    const result = await service.listSkills({
+      page: 2,
+      perPage: 10,
+      q: ' React ',
+      roleCategory: RoleCategory.FRAMEWORKS,
+    });
+
+    expect(prisma.skill.findMany).toHaveBeenCalledWith({
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      select: expectAnyObject(),
+      skip: 10,
+      take: 10,
+      where: {
+        name: {
+          contains: 'React',
+          mode: 'insensitive',
+        },
+        roleCategory: RoleCategory.FRAMEWORKS,
+      },
+    });
+    expect(prisma.skill.count).toHaveBeenCalledWith({
+      where: {
+        name: {
+          contains: 'React',
+          mode: 'insensitive',
+        },
+        roleCategory: RoleCategory.FRAMEWORKS,
+      },
+    });
+    expect(result).toEqual({
+      data: [
+        {
+          createdAt: '2026-01-01T00:00:00.000Z',
+          defaultEstimatedHours: 6.5,
+          description: 'Skill description',
+          id: skillId,
+          name: 'React Fundamentals',
+          roleCategory: RoleCategory.FRAMEWORKS,
+          updatedAt: '2026-01-02T00:00:00.000Z',
+        },
+      ],
+      meta: {
+        page: 2,
+        perPage: 10,
+        total: 21,
+        totalPages: 3,
+      },
+    });
+  });
+
+  it('uses default pagination when page and perPage are omitted', async () => {
+    prisma.skill.findMany.mockResolvedValue([]);
+    prisma.skill.count.mockResolvedValue(0);
+
+    const result = await service.listSkills({});
+
+    expect(prisma.skill.findMany).toHaveBeenCalledWith({
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+      select: expectAnyObject(),
+      skip: 0,
+      take: 20,
+      where: {},
+    });
+    expect(result.meta).toEqual({
+      page: 1,
+      perPage: 20,
+      total: 0,
+      totalPages: 0,
+    });
+  });
+
+  it('creates skills and formats the response', async () => {
+    const skill = makeSkill({
+      defaultEstimatedHours: 4,
+      description: null,
+      name: 'JWT Authentication',
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    });
+
+    prisma.skill.create.mockResolvedValue(skill);
+
+    const result = await service.createSkill({
+      defaultEstimatedHours: 4,
+      name: 'JWT Authentication',
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    });
+
+    expect(prisma.skill.create).toHaveBeenCalledWith({
+      data: {
+        defaultEstimatedHours: 4,
+        description: null,
+        name: 'JWT Authentication',
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      },
+      select: expectAnyObject(),
+    });
+    expect(result).toMatchObject({
+      defaultEstimatedHours: 4,
+      description: null,
+      name: 'JWT Authentication',
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    });
+  });
+
+  it('maps duplicate skill names during creation to a conflict response', async () => {
+    prisma.skill.create.mockRejectedValue(makeUniqueNameError());
+
+    await expectExceptionCode(
+      service.createSkill({
+        name: 'JWT Authentication',
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      }),
+      ErrorCode.CONFLICT,
+    );
+  });
+
+  it('gets skill details with prerequisite summaries ordered by name and id', async () => {
+    const skill = {
+      ...makeSkill({ name: 'NestJS Framework' }),
+      prerequisites: [
+        {
+          prerequisiteSkill: { name: 'Node.js Basics' },
+          prerequisiteSkillId: 'skill-node',
+        },
+        {
+          prerequisiteSkill: { name: 'HTTP Basics' },
+          prerequisiteSkillId: 'skill-http',
+        },
+      ],
+    } satisfies SkillDetailRecord;
+
+    prisma.skill.findUnique.mockResolvedValue(skill);
+
+    const result = await service.getSkill(skillId);
+
+    expect(prisma.skill.findUnique).toHaveBeenCalledWith({
+      select: expectAnyObject(),
+      where: { id: skillId },
+    });
+    expect(result).toMatchObject({
+      id: skillId,
+      name: 'NestJS Framework',
+      prerequisites: [
+        {
+          name: 'HTTP Basics',
+          skillId: 'skill-http',
+        },
+        {
+          name: 'Node.js Basics',
+          skillId: 'skill-node',
+        },
+      ],
+    });
+  });
+
+  it('throws SkillNotFoundException when fetching a missing skill', async () => {
+    prisma.skill.findUnique.mockResolvedValue(null);
+
+    await expectExceptionCode(service.getSkill(skillId), ErrorCode.SKILL_NOT_FOUND);
+  });
+
+  it('updates only explicitly provided fields and preserves omitted fields', async () => {
+    const updatedSkill = makeSkill({
+      defaultEstimatedHours: null,
+      description: null,
+    });
+
+    prisma.skill.findUnique.mockResolvedValue({ id: skillId });
+    prisma.skill.update.mockResolvedValue(updatedSkill);
+
+    const result = await service.updateSkill(skillId, {
+      defaultEstimatedHours: null,
+      description: null,
+    });
+
+    expect(prisma.skill.update).toHaveBeenCalledWith({
+      data: {
+        defaultEstimatedHours: null,
+        description: null,
+      },
+      select: expectAnyObject(),
+      where: { id: skillId },
+    });
+    expect(result).toMatchObject({
+      defaultEstimatedHours: null,
+      description: null,
+    });
+  });
+
+  it('throws SkillNotFoundException when updating a missing skill', async () => {
+    prisma.skill.findUnique.mockResolvedValue(null);
+
+    await expectExceptionCode(
+      service.updateSkill(skillId, { name: 'Updated Skill' }),
+      ErrorCode.SKILL_NOT_FOUND,
+    );
+
+    expect(prisma.skill.update).not.toHaveBeenCalled();
+  });
+
+  it('maps duplicate skill names during update to a conflict response', async () => {
+    prisma.skill.findUnique.mockResolvedValue({ id: skillId });
+    prisma.skill.update.mockRejectedValue(makeUniqueNameError());
+
+    await expectExceptionCode(
+      service.updateSkill(skillId, { name: 'Existing Skill' }),
+      ErrorCode.CONFLICT,
+    );
+  });
+
+  it('deletes unreferenced skills', async () => {
+    prisma.skill.findUnique.mockResolvedValue({ id: skillId });
+    prisma.roadmapNode.findFirst.mockResolvedValue(null);
+    prisma.skill.delete.mockResolvedValue({ id: skillId });
+
+    await expect(service.deleteSkill(skillId)).resolves.toBeUndefined();
+
+    expect(prisma.roadmapNode.findFirst).toHaveBeenCalledWith({
+      select: { id: true },
+      where: { skillId },
+    });
+    expect(prisma.skill.delete).toHaveBeenCalledWith({
+      select: { id: true },
+      where: { id: skillId },
+    });
+  });
+
+  it('blocks deleting skills referenced by roadmap or template nodes', async () => {
+    prisma.skill.findUnique.mockResolvedValue({ id: skillId });
+    prisma.roadmapNode.findFirst.mockResolvedValue({ id: 'node-1' });
+
+    await expectExceptionCode(service.deleteSkill(skillId), ErrorCode.CONFLICT);
+
+    expect(prisma.skill.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws SkillNotFoundException when deleting a missing skill', async () => {
+    prisma.skill.findUnique.mockResolvedValue(null);
+
+    await expectExceptionCode(service.deleteSkill(skillId), ErrorCode.SKILL_NOT_FOUND);
+
+    expect(prisma.roadmapNode.findFirst).not.toHaveBeenCalled();
+    expect(prisma.skill.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/unit/skills/admin-skills.service.spec.ts
+++ b/apps/api/test/unit/skills/admin-skills.service.spec.ts
@@ -263,7 +263,7 @@ describe('AdminSkillsService', () => {
         name: 'JWT Authentication',
         roleCategory: RoleCategory.WEB_DEVELOPMENT,
       }),
-      ErrorCode.CONFLICT,
+      ErrorCode.SKILL_NAME_ALREADY_EXISTS,
     );
   });
 
@@ -357,7 +357,7 @@ describe('AdminSkillsService', () => {
 
     await expectExceptionCode(
       service.updateSkill(skillId, { name: 'Existing Skill' }),
-      ErrorCode.CONFLICT,
+      ErrorCode.SKILL_NAME_ALREADY_EXISTS,
     );
   });
 
@@ -382,7 +382,7 @@ describe('AdminSkillsService', () => {
     prisma.skill.findUnique.mockResolvedValue({ id: skillId });
     prisma.roadmapNode.findFirst.mockResolvedValue({ id: 'node-1' });
 
-    await expectExceptionCode(service.deleteSkill(skillId), ErrorCode.CONFLICT);
+    await expectExceptionCode(service.deleteSkill(skillId), ErrorCode.SKILL_DELETE_REFERENCED);
 
     expect(prisma.skill.delete).not.toHaveBeenCalled();
   });

--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -165,6 +165,10 @@ The following features are **not in the current version scope** but are intentio
 - **NFR-11:** System logs are comprehensive enough for debugging (Winston or Morgan in NestJS).
 - **NFR-12:** If AI roadmap generation fails due to server-side errors (for example Gemini timeout/error), the system must clearly notify users that a server error occurred, ask them to try again later, and suggest checking available default roadmaps while waiting.
 
+**Backend API error contract note:** Skills catalog APIs return structured custom error codes
+for domain failures such as duplicate skill names, referenced skill deletion, invalid prerequisite
+relationships, and missing prerequisite relationships.
+
 ---
 
 ## **4. MODULE ARCHITECTURE OVERVIEW**


### PR DESCRIPTION
## Description

Adds full CRUD management endpoints for the skills catalog under `admin/skills`, including prerequisite relationship management with cycle detection.

## Related Issue

Closes #82

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- `POST/GET /api/v1/admin/skills` — create and paginated list skills (supports search, role category filter)
- `GET/PUT/DELETE /api/v1/admin/skills/:skillId` — get detail, update, and delete a skill
- `GET/POST/DELETE /api/v1/admin/skills/:skillId/prerequisites` — manage prerequisite edges between skills
- Prerequisite cycle detection (self-references + transitive cycles)
- Input validation via Zod DTOs (name trimming, UUID param validation, pagination bounds)
- Duplicate name detection with structured conflict error code
- Delete protection for skills referenced by roadmap/template nodes
- Custom error codes for all domain failures (`SKILL_NAME_ALREADY_EXISTS`, `SKILL_DELETE_REFERENCED`, `SKILL_PREREQUISITE_*`, etc.)
- Full unit test coverage for controllers and services
- Full integration test coverage for all admin skill endpoints
- Updated SRS docs with API error contract note

## How to Test

1. `pnpm --filter api test` — all unit + integration tests pass
2. `pnpm --filter api test:cov` — verify coverage
3. `pnpm lint` and `pnpm check-types`

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

All admin endpoints are guarded by `RolesGuard` requiring `ADMIN` role. The prerequisite cycle detection uses BFS traversal inside a Prisma transaction to ensure atomicity.
