### PR TITLE
[FEATURE] Add admin console with CRUD management for skills, templates, and template nodes

### DIFF
--- a/apps/api/src/common/constants/error-codes.ts
+++ b/apps/api/src/common/constants/error-codes.ts
@@ -58,6 +58,7 @@ export enum ErrorCode {
   SKILL_PREREQUISITE_ALREADY_EXISTS = 40907,
   SKILL_PREREQUISITE_SELF_REFERENCE = 40908,
   SKILL_PREREQUISITE_CYCLE = 40909,
+  SKILL_PRIMARY_RESOURCES_LIMIT = 40910,
   // 429 - Too Many Requests
   RATE_LIMIT_EXCEEDED = 42900,
   TOO_MANY_MESSAGES = 42901,
@@ -138,6 +139,7 @@ export const ErrorMessages: Record<ErrorCode, string> = {
   [ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS]: 'Skill prerequisite relationship already exists',
   [ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE]: 'A skill cannot be a prerequisite of itself',
   [ErrorCode.SKILL_PREREQUISITE_CYCLE]: 'Skill prerequisite relationship would introduce a cycle',
+  [ErrorCode.SKILL_PRIMARY_RESOURCES_LIMIT]: 'Skill already has 2 primary resources',
   // 429 - Too Many Requests
   [ErrorCode.RATE_LIMIT_EXCEEDED]: 'Rate limit exceeded',
   [ErrorCode.TOO_MANY_MESSAGES]: 'Too many messages sent',

--- a/apps/api/src/common/exceptions/app.exceptions.ts
+++ b/apps/api/src/common/exceptions/app.exceptions.ts
@@ -491,6 +491,15 @@ export class SkillPrerequisiteCycleException extends ConflictException {
   }
 }
 
+export class SkillPrimaryResourcesLimitException extends ConflictException {
+  constructor() {
+    super({
+      code: ErrorCode.SKILL_PRIMARY_RESOURCES_LIMIT,
+      message: getErrorMessage(ErrorCode.SKILL_PRIMARY_RESOURCES_LIMIT),
+    });
+  }
+}
+
 // ================
 // 429 - Rate Limit
 // ================
@@ -711,6 +720,7 @@ export const ErrorCodeToException = {
   [ErrorCode.SKILL_PREREQUISITE_ALREADY_EXISTS]: SkillPrerequisiteAlreadyExistsException,
   [ErrorCode.SKILL_PREREQUISITE_SELF_REFERENCE]: SkillPrerequisiteSelfReferenceException,
   [ErrorCode.SKILL_PREREQUISITE_CYCLE]: SkillPrerequisiteCycleException,
+  [ErrorCode.SKILL_PRIMARY_RESOURCES_LIMIT]: SkillPrimaryResourcesLimitException,
   // 429 - Too Many Requests
   [ErrorCode.RATE_LIMIT_EXCEEDED]: RateLimitExceededException,
   [ErrorCode.TOO_MANY_MESSAGES]: TooManyMessagesException,

--- a/apps/api/src/modules/skills/admin-skill-resources.service.ts
+++ b/apps/api/src/modules/skills/admin-skill-resources.service.ts
@@ -3,6 +3,7 @@ import { type Prisma, type Resource } from '@repo/db/prisma/client';
 
 import {
   ResourceNotFoundException,
+  SkillPrimaryResourcesLimitException,
   SkillNotFoundException,
 } from '@/common/exceptions/app.exceptions';
 import { PrismaService } from '@/modules/prisma/prisma.service';
@@ -57,6 +58,9 @@ export class AdminSkillResourcesService {
       await this.findSkillOrThrow(skillId, tx);
 
       const isPrimary = dto.isPrimary ?? false;
+      if (isPrimary) {
+        await this.ensurePrimaryResourceLimit(skillId, tx);
+      }
 
       return tx.resource.create({
         data: {
@@ -81,7 +85,10 @@ export class AdminSkillResourcesService {
   ): Promise<SkillResourceResponse> {
     const resource = await this.prisma.$transaction(async (tx) => {
       await this.findSkillOrThrow(skillId, tx);
-      await this.findResourceOrThrow(skillId, resourceId, tx);
+      const existingResource = await this.findResourceOrThrow(skillId, resourceId, tx);
+      if (dto.isPrimary === true && !existingResource.isPrimary) {
+        await this.ensurePrimaryResourceLimit(skillId, tx, resourceId);
+      }
 
       return tx.resource.update({
         data: {
@@ -97,6 +104,24 @@ export class AdminSkillResourcesService {
     });
 
     return this.formatResource(resource);
+  }
+
+  private async ensurePrimaryResourceLimit(
+    skillId: string,
+    prisma: Pick<PrismaService, 'resource'>,
+    excludedResourceId?: number,
+  ): Promise<void> {
+    const primaryResourceCount = await prisma.resource.count({
+      where: {
+        ...(excludedResourceId ? { id: { not: excludedResourceId } } : {}),
+        isPrimary: true,
+        skillId,
+      },
+    });
+
+    if (primaryResourceCount >= 2) {
+      throw new SkillPrimaryResourcesLimitException();
+    }
   }
 
   async deleteResource(skillId: string, resourceId: number): Promise<void> {

--- a/apps/api/src/modules/templates/admin-templates.controller.ts
+++ b/apps/api/src/modules/templates/admin-templates.controller.ts
@@ -19,6 +19,7 @@ import { Roles } from '@/common/decorators/roles.decorator';
 import type {
   AdminTemplatesListResponse,
   TemplateNodeResponse,
+  TemplateNodesListResponse,
 } from './types/admin-template-response.types';
 
 import { AdminTemplatesService } from './admin-templates.service';
@@ -60,6 +61,11 @@ export class AdminTemplatesController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async remove(@Param() params: TemplateIdParamDto): Promise<void> {
     await this.adminTemplatesService.deleteTemplate(params.templateId);
+  }
+
+  @Get(':templateId/nodes')
+  async listNodes(@Param() params: TemplateIdParamDto): Promise<TemplateNodesListResponse> {
+    return this.adminTemplatesService.listNodes(params.templateId);
   }
 
   @Post(':templateId/nodes')

--- a/apps/api/src/modules/templates/admin-templates.controller.ts
+++ b/apps/api/src/modules/templates/admin-templates.controller.ts
@@ -1,15 +1,30 @@
-import { Body, Controller, Delete, HttpCode, HttpStatus, Param, Post, Put } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
 import { UserRole } from '@repo/db/prisma/client';
 
 import type { RoadmapResponseDto } from '@/modules/roadmaps/dto/roadmap-response.dto';
 
 import { Roles } from '@/common/decorators/roles.decorator';
 
-import type { TemplateNodeResponse } from './types/admin-template-response.types';
+import type {
+  AdminTemplatesListResponse,
+  TemplateNodeResponse,
+} from './types/admin-template-response.types';
 
 import { AdminTemplatesService } from './admin-templates.service';
 import { CreateTemplateNodeDto, UpdateTemplateNodeDto } from './dto/admin-template-node.dto';
 import { TemplateIdParamDto, TemplateNodeIdParamDto } from './dto/admin-template-params.dto';
+import { ListAdminTemplatesQueryDto } from './dto/admin-template-query.dto';
 import { CreateTemplateDto, UpdateTemplateDto } from './dto/admin-template.dto';
 
 @Controller('admin/templates')
@@ -17,10 +32,20 @@ import { CreateTemplateDto, UpdateTemplateDto } from './dto/admin-template.dto';
 export class AdminTemplatesController {
   constructor(private readonly adminTemplatesService: AdminTemplatesService) {}
 
+  @Get()
+  async list(@Query() query: ListAdminTemplatesQueryDto): Promise<AdminTemplatesListResponse> {
+    return this.adminTemplatesService.listTemplates(query);
+  }
+
   @Post()
   @HttpCode(HttpStatus.CREATED)
   async create(@Body() dto: CreateTemplateDto): Promise<RoadmapResponseDto> {
     return this.adminTemplatesService.createTemplate(dto);
+  }
+
+  @Get(':templateId')
+  async get(@Param() params: TemplateIdParamDto): Promise<RoadmapResponseDto> {
+    return this.adminTemplatesService.getTemplate(params.templateId);
   }
 
   @Put(':templateId')

--- a/apps/api/src/modules/templates/admin-templates.service.ts
+++ b/apps/api/src/modules/templates/admin-templates.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@repo/db/prisma/client';
 
 import type { RoadmapResponseDto } from '@/modules/roadmaps/dto/roadmap-response.dto';
+import type { FlatNode } from '@/modules/roadmaps/types/ai-roadmap.types';
 
 import {
   RoadmapNodeNotFoundException,
@@ -18,6 +19,7 @@ import {
   TemplateNodeInvalidValueException,
 } from '@/common/exceptions/app.exceptions';
 import { PrismaService } from '@/modules/prisma/prisma.service';
+import { DagreLayoutService } from '@/modules/roadmaps/services/dagre-layout.service';
 
 import type { CreateTemplateNodeDto, UpdateTemplateNodeDto } from './dto/admin-template-node.dto';
 import type { ListAdminTemplatesQueryDto } from './dto/admin-template-query.dto';
@@ -25,11 +27,13 @@ import type { CreateTemplateDto, UpdateTemplateDto } from './dto/admin-template.
 import type {
   AdminTemplatesListResponse,
   TemplateNodeResponse,
+  TemplateNodesListResponse,
 } from './types/admin-template-response.types';
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PER_PAGE = 20;
 const LEAF_NODE_TYPES: NodeType[] = [NodeType.REQUIRED, NodeType.OPTIONAL];
+const AXIS_NODE_TYPES: NodeType[] = [NodeType.GROUP, NodeType.MILESTONE];
 
 const TEMPLATE_ROADMAP_SELECT = {
   deadlineDate: true,
@@ -74,8 +78,6 @@ type NodeState = {
   name: string;
   nodeType: NodeType;
   parentId: null | string;
-  posX: DecimalLike | number;
-  posY: DecimalLike | number;
   skillId: null | string;
 };
 
@@ -86,7 +88,10 @@ type TemplateSummary = {
 
 @Injectable()
 export class AdminTemplatesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly dagreLayout: DagreLayoutService,
+  ) {}
 
   async listTemplates(query: ListAdminTemplatesQueryDto): Promise<AdminTemplatesListResponse> {
     const page = query.page ?? DEFAULT_PAGE;
@@ -168,6 +173,23 @@ export class AdminTemplatesService {
     }
   }
 
+  async listNodes(templateId: string): Promise<TemplateNodesListResponse> {
+    await this.findTemplateOrThrow(templateId);
+
+    const nodes = await this.prisma.roadmapNode.findMany({
+      orderBy: [{ posY: 'asc' }, { posX: 'asc' }, { id: 'asc' }],
+      select: TEMPLATE_NODE_SELECT,
+      where: {
+        roadmapId: templateId,
+        roadmap: { isTemplate: true },
+      },
+    });
+
+    return {
+      nodes: nodes.map((node) => this.formatNode(node)),
+    };
+  }
+
   async createNode(templateId: string, dto: CreateTemplateNodeDto): Promise<TemplateNodeResponse> {
     const template = await this.findTemplateOrThrow(templateId);
     const state = {
@@ -176,8 +198,6 @@ export class AdminTemplatesService {
       name: dto.name,
       nodeType: dto.nodeType,
       parentId: dto.parentId ?? null,
-      posX: dto.posX,
-      posY: dto.posY,
       skillId: dto.skillId ?? null,
     } satisfies NodeState;
 
@@ -190,15 +210,17 @@ export class AdminTemplatesService {
         name: state.name,
         nodeType: state.nodeType,
         parentId: state.parentId,
-        posX: state.posX,
-        posY: state.posY,
+        posX: 0,
+        posY: 0,
         roadmapId: templateId,
         skillId: state.skillId,
       },
       select: TEMPLATE_NODE_SELECT,
     });
 
-    return this.formatNode(node);
+    await this.recalculateTemplateLayout(templateId);
+
+    return this.formatNode(await this.findNodeOrThrow(templateId, node.id));
   }
 
   async updateNode(
@@ -218,12 +240,10 @@ export class AdminTemplatesService {
       name: this.hasOwn(dto, 'name') ? dto.name! : existingNode.name,
       nodeType: this.hasOwn(dto, 'nodeType') ? dto.nodeType! : existingNode.nodeType,
       parentId: this.hasOwn(dto, 'parentId') ? (dto.parentId ?? null) : existingNode.parentId,
-      posX: this.hasOwn(dto, 'posX') ? dto.posX! : existingNode.posX,
-      posY: this.hasOwn(dto, 'posY') ? dto.posY! : existingNode.posY,
       skillId: this.hasOwn(dto, 'skillId') ? (dto.skillId ?? null) : existingNode.skillId,
     } satisfies NodeState;
 
-    await this.validateNodeState(template, state);
+    await this.validateNodeState(template, state, nodeId);
 
     const node = await this.prisma.roadmapNode.update({
       data: {
@@ -232,15 +252,15 @@ export class AdminTemplatesService {
         ...(this.hasOwn(dto, 'name') ? { name: state.name } : {}),
         ...(this.hasOwn(dto, 'nodeType') ? { nodeType: state.nodeType } : {}),
         ...(this.hasOwn(dto, 'parentId') ? { parentId: state.parentId } : {}),
-        ...(this.hasOwn(dto, 'posX') ? { posX: state.posX } : {}),
-        ...(this.hasOwn(dto, 'posY') ? { posY: state.posY } : {}),
         ...(this.hasOwn(dto, 'skillId') ? { skillId: state.skillId } : {}),
       },
       select: TEMPLATE_NODE_SELECT,
       where: { id: nodeId },
     });
 
-    return this.formatNode(node);
+    await this.recalculateTemplateLayout(templateId);
+
+    return this.formatNode(await this.findNodeOrThrow(templateId, node.id));
   }
 
   async deleteNode(templateId: string, nodeId: string): Promise<void> {
@@ -262,7 +282,7 @@ export class AdminTemplatesService {
       throw new RoadmapNodeNotFoundException(nodeId);
     }
 
-    if (node.nodeType === NodeType.GROUP) {
+    if (AXIS_NODE_TYPES.includes(node.nodeType)) {
       await this.prisma.$transaction(async (tx) => {
         await tx.roadmapNode.deleteMany({
           where: {
@@ -275,11 +295,12 @@ export class AdminTemplatesService {
         await tx.roadmapNode.deleteMany({
           where: {
             id: nodeId,
-            nodeType: NodeType.GROUP,
+            nodeType: { in: AXIS_NODE_TYPES },
             roadmapId: templateId,
           },
         });
       });
+      await this.recalculateTemplateLayout(templateId);
       return;
     }
 
@@ -293,6 +314,8 @@ export class AdminTemplatesService {
     if (result.count === 0) {
       throw new RoadmapNodeNotFoundException(nodeId);
     }
+
+    await this.recalculateTemplateLayout(templateId);
   }
 
   private buildTemplateWhere(query: ListAdminTemplatesQueryDto): Prisma.RoadmapWhereInput {
@@ -348,10 +371,11 @@ export class AdminTemplatesService {
     return node;
   }
 
-  private async validateNodeState(template: TemplateSummary, state: NodeState): Promise<void> {
-    this.assertFiniteNumber('posX', state.posX);
-    this.assertFiniteNumber('posY', state.posY);
-
+  private async validateNodeState(
+    template: TemplateSummary,
+    state: NodeState,
+    currentNodeId?: string,
+  ): Promise<void> {
     if (state.estimatedHours !== null) {
       this.assertFiniteNumber('estimatedHours', state.estimatedHours);
       if (this.toNumber(state.estimatedHours) < 0) {
@@ -380,18 +404,22 @@ export class AdminTemplatesService {
     }
 
     if (!state.parentId) {
-      throw new TemplateNodeInvalidReferenceException('Leaf nodes require a parent group');
+      throw new TemplateNodeInvalidReferenceException('Leaf nodes require a parent section');
     }
 
     if (!state.skillId) {
       throw new TemplateNodeInvalidReferenceException('Leaf nodes require a skill');
     }
 
+    if (state.parentId === currentNodeId) {
+      throw new TemplateNodeInvalidReferenceException('Leaf nodes cannot be their own parent');
+    }
+
     const parent = await this.prisma.roadmapNode.findFirst({
       select: { id: true },
       where: {
         id: state.parentId,
-        nodeType: NodeType.GROUP,
+        nodeType: { in: AXIS_NODE_TYPES },
         roadmapId: template.id,
         roadmap: { isTemplate: true },
       },
@@ -399,8 +427,23 @@ export class AdminTemplatesService {
 
     if (!parent) {
       throw new TemplateNodeInvalidReferenceException(
-        'Leaf node parent must be a group in the same template',
+        'Leaf node parent must be a group or milestone in the same template',
       );
+    }
+
+    if (currentNodeId && LEAF_NODE_TYPES.includes(state.nodeType)) {
+      const childrenCount = await this.prisma.roadmapNode.count({
+        where: {
+          parentId: currentNodeId,
+          roadmapId: template.id,
+        },
+      });
+
+      if (childrenCount > 0) {
+        throw new TemplateNodeInvalidShapeException(
+          'Section nodes with children cannot be converted to leaf nodes',
+        );
+      }
     }
 
     const skill = await this.prisma.skill.findUnique({
@@ -420,6 +463,51 @@ export class AdminTemplatesService {
         'Skill role category does not match the template',
       );
     }
+  }
+
+  private async recalculateTemplateLayout(templateId: string): Promise<void> {
+    const nodes = await this.prisma.roadmapNode.findMany({
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      select: TEMPLATE_NODE_SELECT,
+      where: {
+        roadmapId: templateId,
+        roadmap: { isTemplate: true },
+      },
+    });
+
+    if (nodes.length === 0) {
+      return;
+    }
+
+    const flatNodes = nodes.map<FlatNode>((node) => ({
+      description: node.description,
+      estimatedHours: this.formatDecimal(node.estimatedHours),
+      name: node.name,
+      nodeType: node.nodeType,
+      realId: node.id,
+      realParentId: node.parentId,
+      skillId: node.skillId,
+      tempId: node.id,
+      tempParentId: node.parentId,
+    }));
+    const layout = this.dagreLayout.computeLayout(flatNodes);
+
+    await this.prisma.$transaction(
+      nodes.map((node) => {
+        const position = layout.get(node.id) ?? { posX: 0, posY: 0 };
+
+        return this.prisma.roadmapNode.updateMany({
+          data: {
+            posX: position.posX,
+            posY: position.posY,
+          },
+          where: {
+            id: node.id,
+            roadmapId: templateId,
+          },
+        });
+      }),
+    );
   }
 
   private assertNullFields(state: NodeState, fields: Array<keyof NodeState>): void {

--- a/apps/api/src/modules/templates/admin-templates.service.ts
+++ b/apps/api/src/modules/templates/admin-templates.service.ts
@@ -20,9 +20,15 @@ import {
 import { PrismaService } from '@/modules/prisma/prisma.service';
 
 import type { CreateTemplateNodeDto, UpdateTemplateNodeDto } from './dto/admin-template-node.dto';
+import type { ListAdminTemplatesQueryDto } from './dto/admin-template-query.dto';
 import type { CreateTemplateDto, UpdateTemplateDto } from './dto/admin-template.dto';
-import type { TemplateNodeResponse } from './types/admin-template-response.types';
+import type {
+  AdminTemplatesListResponse,
+  TemplateNodeResponse,
+} from './types/admin-template-response.types';
 
+const DEFAULT_PAGE = 1;
+const DEFAULT_PER_PAGE = 20;
 const LEAF_NODE_TYPES: NodeType[] = [NodeType.REQUIRED, NodeType.OPTIONAL];
 
 const TEMPLATE_ROADMAP_SELECT = {
@@ -82,6 +88,33 @@ type TemplateSummary = {
 export class AdminTemplatesService {
   constructor(private readonly prisma: PrismaService) {}
 
+  async listTemplates(query: ListAdminTemplatesQueryDto): Promise<AdminTemplatesListResponse> {
+    const page = query.page ?? DEFAULT_PAGE;
+    const perPage = query.perPage ?? DEFAULT_PER_PAGE;
+    const where = this.buildTemplateWhere(query);
+
+    const [templates, total] = await this.prisma.$transaction([
+      this.prisma.roadmap.findMany({
+        orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
+        select: TEMPLATE_ROADMAP_SELECT,
+        skip: (page - 1) * perPage,
+        take: perPage,
+        where,
+      }),
+      this.prisma.roadmap.count({ where }),
+    ]);
+
+    return {
+      data: templates.map((template) => this.formatRoadmap(template)),
+      meta: {
+        page,
+        perPage,
+        total,
+        totalPages: Math.ceil(total / perPage),
+      },
+    };
+  }
+
   async createTemplate(dto: CreateTemplateDto): Promise<RoadmapResponseDto> {
     const roadmap = await this.prisma.roadmap.create({
       data: {
@@ -101,6 +134,10 @@ export class AdminTemplatesService {
     return this.formatRoadmap(roadmap);
   }
 
+  async getTemplate(templateId: string): Promise<RoadmapResponseDto> {
+    return this.formatRoadmap(await this.findTemplateOrThrow(templateId));
+  }
+
   async updateTemplate(templateId: string, dto: UpdateTemplateDto): Promise<RoadmapResponseDto> {
     await this.findTemplateOrThrow(templateId);
 
@@ -108,6 +145,7 @@ export class AdminTemplatesService {
       data: {
         ...(this.hasOwn(dto, 'description') ? { description: dto.description } : {}),
         ...(this.hasOwn(dto, 'estimatedWeeks') ? { estimatedWeeks: dto.estimatedWeeks } : {}),
+        ...(this.hasOwn(dto, 'roleCategory') ? { roleCategory: dto.roleCategory } : {}),
         ...(this.hasOwn(dto, 'title') ? { title: dto.title } : {}),
       },
       select: TEMPLATE_ROADMAP_SELECT,
@@ -255,6 +293,26 @@ export class AdminTemplatesService {
     if (result.count === 0) {
       throw new RoadmapNodeNotFoundException(nodeId);
     }
+  }
+
+  private buildTemplateWhere(query: ListAdminTemplatesQueryDto): Prisma.RoadmapWhereInput {
+    const where: Prisma.RoadmapWhereInput = {
+      isTemplate: true,
+    };
+    const searchQuery = query.q?.trim();
+
+    if (query.roleCategory) {
+      where.roleCategory = query.roleCategory;
+    }
+
+    if (searchQuery) {
+      where.title = {
+        contains: searchQuery,
+        mode: 'insensitive',
+      };
+    }
+
+    return where;
   }
 
   private async findTemplateOrThrow(templateId: string): Promise<SelectedTemplate> {

--- a/apps/api/src/modules/templates/dto/admin-template-node.dto.ts
+++ b/apps/api/src/modules/templates/dto/admin-template-node.dto.ts
@@ -51,14 +51,6 @@ export class CreateTemplateNodeDto {
   @IsNumber({ allowInfinity: false, allowNaN: false })
   @Min(0)
   estimatedHours?: null | number;
-
-  @Type(() => Number)
-  @IsNumber({ allowInfinity: false, allowNaN: false })
-  posX!: number;
-
-  @Type(() => Number)
-  @IsNumber({ allowInfinity: false, allowNaN: false })
-  posY!: number;
 }
 
 export class UpdateTemplateNodeDto {
@@ -94,14 +86,4 @@ export class UpdateTemplateNodeDto {
   @IsNumber({ allowInfinity: false, allowNaN: false })
   @Min(0)
   estimatedHours?: null | number;
-
-  @ValidateIf(isDefined)
-  @Type(() => Number)
-  @IsNumber({ allowInfinity: false, allowNaN: false })
-  posX?: number;
-
-  @ValidateIf(isDefined)
-  @Type(() => Number)
-  @IsNumber({ allowInfinity: false, allowNaN: false })
-  posY?: number;
 }

--- a/apps/api/src/modules/templates/dto/admin-template-query.dto.ts
+++ b/apps/api/src/modules/templates/dto/admin-template-query.dto.ts
@@ -1,0 +1,34 @@
+import { RoleCategory } from '@repo/db/prisma/client';
+import { Transform, Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+const toTrimmedString = ({ value }): unknown => (typeof value === 'string' ? value.trim() : value);
+
+const toUppercaseString = ({ value }): unknown =>
+  typeof value === 'string' ? value.toUpperCase() : value;
+
+export class ListAdminTemplatesQueryDto {
+  @IsOptional()
+  @Transform(toUppercaseString)
+  @IsEnum(RoleCategory)
+  roleCategory?: RoleCategory;
+
+  @IsOptional()
+  @Transform(toTrimmedString)
+  @IsString()
+  @MaxLength(200)
+  q?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  perPage?: number;
+}

--- a/apps/api/src/modules/templates/dto/admin-template.dto.ts
+++ b/apps/api/src/modules/templates/dto/admin-template.dto.ts
@@ -1,5 +1,5 @@
 import { RoleCategory } from '@repo/db/prisma/client';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import {
   IsEnum,
   IsInt,
@@ -18,6 +18,18 @@ const toTrimmedString = ({ value }): unknown => (typeof value === 'string' ? val
 const toUppercaseString = ({ value }): unknown =>
   typeof value === 'string' ? value.toUpperCase() : value;
 
+const toNullableNumber = ({ value }): unknown => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null || value === '') {
+    return null;
+  }
+
+  return Number(value);
+};
+
 export class CreateTemplateDto {
   @Transform(toTrimmedString)
   @IsString()
@@ -35,8 +47,8 @@ export class CreateTemplateDto {
   @MaxLength(2000)
   description!: string;
 
-  @ValidateIf(isDefined)
-  @Type(() => Number)
+  @ValidateIf((_object, value) => value !== undefined && value !== null)
+  @Transform(toNullableNumber)
   @IsInt()
   @Min(1)
   @Max(520)
@@ -52,14 +64,19 @@ export class UpdateTemplateDto {
   title?: string;
 
   @ValidateIf(isDefined)
+  @Transform(toUppercaseString)
+  @IsEnum(RoleCategory)
+  roleCategory?: RoleCategory;
+
+  @ValidateIf(isDefined)
   @Transform(toTrimmedString)
   @IsString()
   @IsNotEmpty()
   @MaxLength(2000)
   description?: string;
 
-  @ValidateIf(isDefined)
-  @Type(() => Number)
+  @ValidateIf((_object, value) => value !== undefined && value !== null)
+  @Transform(toNullableNumber)
   @IsInt()
   @Min(1)
   @Max(520)

--- a/apps/api/src/modules/templates/templates.module.ts
+++ b/apps/api/src/modules/templates/templates.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { PrismaModule } from '../prisma/prisma.module';
+import { DagreLayoutService } from '../roadmaps/services/dagre-layout.service';
 import { AdminTemplatesController } from './admin-templates.controller';
 import { AdminTemplatesService } from './admin-templates.service';
 import { TemplatesController } from './templates.controller';
@@ -9,7 +10,7 @@ import { TemplatesService } from './templates.service';
 @Module({
   imports: [PrismaModule],
   controllers: [TemplatesController, AdminTemplatesController],
-  providers: [TemplatesService, AdminTemplatesService],
+  providers: [TemplatesService, AdminTemplatesService, DagreLayoutService],
   exports: [TemplatesService],
 })
 export class TemplatesModule {}

--- a/apps/api/src/modules/templates/types/admin-template-response.types.ts
+++ b/apps/api/src/modules/templates/types/admin-template-response.types.ts
@@ -1,5 +1,15 @@
 import type { NodeType } from '@repo/db/prisma/client';
 
+import type {
+  PaginationMetaDto,
+  RoadmapResponseDto,
+} from '@/modules/roadmaps/dto/roadmap-response.dto';
+
+export interface AdminTemplatesListResponse {
+  data: RoadmapResponseDto[];
+  meta: PaginationMetaDto;
+}
+
 export interface TemplateNodeResponse {
   createdAt: string;
   description: null | string;

--- a/apps/api/test/integration/admin-skill-resources.integration-spec.ts
+++ b/apps/api/test/integration/admin-skill-resources.integration-spec.ts
@@ -1,6 +1,8 @@
 import { ResourceType, RoleCategory, UserRole } from '@repo/db/prisma/client';
 import request from 'supertest';
 
+import { ErrorCode } from '@/common/constants/error-codes';
+
 import { getCookieHeader } from './utils/cookies';
 import { seedUser, uniqueEmail } from './utils/database';
 import { setupIntegrationTest } from './utils/integration-test-context';
@@ -195,7 +197,7 @@ describe('Admin skill resource management (integration)', () => {
     });
   });
 
-  it('allows additional primary resources and returns 404 for missing references', async () => {
+  it('rejects third primary resources and returns 404 for missing references', async () => {
     const admin = await seedUser(integration.prisma, {
       email: uniqueEmail('resource-error-admin'),
       role: UserRole.ADMIN,
@@ -253,12 +255,11 @@ describe('Admin skill resource management (integration)', () => {
         title: 'Third primary',
         url: 'https://example.test/third',
       })
-      .expect(201);
+      .expect(409);
 
     expect(thirdPrimaryResponse.body).toMatchObject({
-      isPrimary: true,
-      resourceType: ResourceType.COURSE,
-      title: 'Third primary',
+      code: ErrorCode.SKILL_PRIMARY_RESOURCES_LIMIT,
+      message: 'Skill already has 2 primary resources',
     });
 
     await request(integration.app.getHttpServer())

--- a/apps/api/test/integration/admin-templates.integration-spec.ts
+++ b/apps/api/test/integration/admin-templates.integration-spec.ts
@@ -81,11 +81,12 @@ describe('Admin template management (integration)', () => {
       .send({
         name: 'Template Group',
         nodeType: 'group',
-        posX: 0,
-        posY: 0,
       })
       .expect(201);
-    const group = groupResponse.body as { id: string };
+    const group = groupResponse.body as { id: string; posX: number; posY: number };
+
+    expect(group.posX).toEqual(expect.any(Number));
+    expect(group.posY).toEqual(expect.any(Number));
 
     const skill = await integration.prisma.skill.create({
       data: {
@@ -104,12 +105,38 @@ describe('Admin template management (integration)', () => {
         name: 'Template Required Skill',
         nodeType: 'required',
         parentId: group.id,
-        posX: 100,
-        posY: 100,
         skillId: skill.id,
       })
       .expect(201);
-    const leaf = leafResponse.body as { id: string };
+    const leaf = leafResponse.body as { id: string; posX: number; posY: number };
+
+    expect(leaf.posX).toEqual(expect.any(Number));
+    expect(leaf.posY).toEqual(expect.any(Number));
+
+    const listNodesResponse = await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/templates/${template.id}/nodes`)
+      .set('Cookie', cookie)
+      .expect(200);
+    const listNodesBody = listNodesResponse.body as {
+      nodes: Array<{ id: string; parentId: null | string; posX: number; posY: number }>;
+    };
+
+    expect(listNodesBody.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: group.id,
+          parentId: null,
+          posX: expect.any(Number) as number,
+          posY: expect.any(Number) as number,
+        }),
+        expect.objectContaining({
+          id: leaf.id,
+          parentId: group.id,
+          posX: expect.any(Number) as number,
+          posY: expect.any(Number) as number,
+        }),
+      ]),
+    );
 
     const updateNodeResponse = await request(integration.app.getHttpServer())
       .put(`/api/v1/admin/templates/${template.id}/nodes/${leaf.id}`)
@@ -117,7 +144,6 @@ describe('Admin template management (integration)', () => {
       .send({
         estimatedHours: 7,
         name: 'Updated Required Skill',
-        posX: 150,
       })
       .expect(200);
 
@@ -125,13 +151,24 @@ describe('Admin template management (integration)', () => {
       estimatedHours: 7,
       id: leaf.id,
       name: 'Updated Required Skill',
-      posX: 150,
+      posX: expect.any(Number) as number,
+      posY: expect.any(Number) as number,
     });
 
     await request(integration.app.getHttpServer())
       .delete(`/api/v1/admin/templates/${template.id}/nodes/${group.id}`)
       .set('Cookie', cookie)
       .expect(204);
+
+    await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/templates/${template.id}/nodes`)
+      .set('Cookie', cookie)
+      .expect(200)
+      .expect((response) => {
+        const body = response.body as { nodes: unknown[] };
+
+        expect(body.nodes).toHaveLength(0);
+      });
 
     await request(integration.app.getHttpServer())
       .delete(`/api/v1/admin/templates/${template.id}`)

--- a/apps/api/test/integration/admin-templates.integration-spec.ts
+++ b/apps/api/test/integration/admin-templates.integration-spec.ts
@@ -28,6 +28,36 @@ describe('Admin template management (integration)', () => {
       .expect(201);
     const template = templateResponse.body as { id: string };
 
+    const listTemplatesResponse = await request(integration.app.getHttpServer())
+      .get('/api/v1/admin/templates')
+      .query({ q: 'Main Flow Template', roleCategory: 'web_development' })
+      .set('Cookie', cookie)
+      .expect(200);
+    const listTemplatesBody = listTemplatesResponse.body as {
+      data: Array<{ id: string; title: string }>;
+      meta: { total: number };
+    };
+
+    expect(listTemplatesBody.data).toHaveLength(1);
+    expect(listTemplatesBody.data[0]).toMatchObject({
+      id: template.id,
+      title: 'Main Flow Template',
+    });
+    expect(listTemplatesBody.meta.total).toBe(1);
+
+    await request(integration.app.getHttpServer())
+      .get(`/api/v1/admin/templates/${template.id}`)
+      .set('Cookie', cookie)
+      .expect(200)
+      .expect((response) => {
+        const body = response.body as { id: string; title: string };
+
+        expect(body).toMatchObject({
+          id: template.id,
+          title: 'Main Flow Template',
+        });
+      });
+
     const updateTemplateResponse = await request(integration.app.getHttpServer())
       .put(`/api/v1/admin/templates/${template.id}`)
       .set('Cookie', cookie)

--- a/apps/api/test/unit/skills/admin-skill-resources.service.spec.ts
+++ b/apps/api/test/unit/skills/admin-skill-resources.service.spec.ts
@@ -27,6 +27,7 @@ interface ResourceRecord {
 
 interface TxMock {
   resource: {
+    count: AsyncMock<number>;
     create: AsyncMock<ResourceRecord>;
     findFirst: AsyncMock<ResourceRecord | null>;
     update: AsyncMock<ResourceRecord>;
@@ -83,6 +84,7 @@ const expectAnyObject = (): object => expect.any(Object) as object;
 
 const makeTxMock = (): TxMock => ({
   resource: {
+    count: jest.fn<Promise<number>, unknown[]>(),
     create: jest.fn<Promise<ResourceRecord>, unknown[]>(),
     findFirst: jest.fn<Promise<ResourceRecord | null>, unknown[]>(),
     update: jest.fn<Promise<ResourceRecord>, unknown[]>(),
@@ -198,10 +200,11 @@ describe('AdminSkillResourcesService', () => {
     });
   });
 
-  it('allows creating additional primary resources', async () => {
+  it('creates a primary resource when fewer than 2 primary resources exist', async () => {
     const resource = makeResource({ isPrimary: true });
 
     txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.resource.count.mockResolvedValue(1);
     txMock.resource.create.mockResolvedValue(resource);
 
     const result = await service.createResource(skillId, {
@@ -211,6 +214,12 @@ describe('AdminSkillResourcesService', () => {
       url: 'https://example.test/docs',
     });
 
+    expect(txMock.resource.count).toHaveBeenCalledWith({
+      where: {
+        isPrimary: true,
+        skillId,
+      },
+    });
     expect(txMock.resource.create).toHaveBeenCalledWith({
       data: {
         isFree: true,
@@ -225,15 +234,40 @@ describe('AdminSkillResourcesService', () => {
     expect(result).toMatchObject({ isPrimary: true });
   });
 
-  it('allows updating a non-primary resource to primary without checking a primary limit', async () => {
+  it('throws SkillPrimaryResourcesLimitException when creating a third primary resource', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.resource.count.mockResolvedValue(2);
+
+    await expectExceptionCode(
+      service.createResource(skillId, {
+        isPrimary: true,
+        resourceType: ResourceType.DOCS,
+        title: 'Official docs',
+        url: 'https://example.test/docs',
+      }),
+      ErrorCode.SKILL_PRIMARY_RESOURCES_LIMIT,
+    );
+
+    expect(txMock.resource.create).not.toHaveBeenCalled();
+  });
+
+  it('allows updating a non-primary resource to primary when fewer than 2 primary resources exist', async () => {
     const updatedResource = makeResource({ isPrimary: true });
 
     txMock.skill.findUnique.mockResolvedValue({ id: skillId });
     txMock.resource.findFirst.mockResolvedValue(makeResource({ isPrimary: false }));
+    txMock.resource.count.mockResolvedValue(1);
     txMock.resource.update.mockResolvedValue(updatedResource);
 
     const result = await service.updateResource(skillId, resourceId, { isPrimary: true });
 
+    expect(txMock.resource.count).toHaveBeenCalledWith({
+      where: {
+        id: { not: resourceId },
+        isPrimary: true,
+        skillId,
+      },
+    });
     expect(txMock.resource.update).toHaveBeenCalledWith({
       data: {
         isPrimary: true,
@@ -242,6 +276,19 @@ describe('AdminSkillResourcesService', () => {
       where: { id: resourceId },
     });
     expect(result).toMatchObject({ isPrimary: true });
+  });
+
+  it('throws SkillPrimaryResourcesLimitException when updating a third resource to primary', async () => {
+    txMock.skill.findUnique.mockResolvedValue({ id: skillId });
+    txMock.resource.findFirst.mockResolvedValue(makeResource({ isPrimary: false }));
+    txMock.resource.count.mockResolvedValue(2);
+
+    await expectExceptionCode(
+      service.updateResource(skillId, resourceId, { isPrimary: true }),
+      ErrorCode.SKILL_PRIMARY_RESOURCES_LIMIT,
+    );
+
+    expect(txMock.resource.update).not.toHaveBeenCalled();
   });
 
   it('allows updating an existing primary resource without false-positive primary conflicts', async () => {
@@ -264,6 +311,7 @@ describe('AdminSkillResourcesService', () => {
       select: expectAnyObject(),
       where: { id: resourceId },
     });
+    expect(txMock.resource.count).not.toHaveBeenCalled();
     expect(result).toMatchObject({ isPrimary: true, title: 'Updated docs' });
   });
 

--- a/apps/api/test/unit/templates/admin-templates.controller.spec.ts
+++ b/apps/api/test/unit/templates/admin-templates.controller.spec.ts
@@ -24,6 +24,7 @@ describe('AdminTemplatesController', () => {
     deleteNode: jest.fn(),
     deleteTemplate: jest.fn(),
     getTemplate: jest.fn(),
+    listNodes: jest.fn(),
     listTemplates: jest.fn(),
     updateNode: jest.fn(),
     updateTemplate: jest.fn(),
@@ -124,8 +125,6 @@ describe('AdminTemplatesController', () => {
       name: 'HTTP APIs',
       nodeType: NodeType.REQUIRED,
       parentId: nodeId,
-      posX: 100,
-      posY: 200,
       skillId: '6f9619ff-8b86-d011-b42d-00cf4fc964ff',
     };
     const response = { id: nodeId };
@@ -138,9 +137,20 @@ describe('AdminTemplatesController', () => {
     expect(result).toEqual(response);
   });
 
+  it('delegates node listing with path params', async () => {
+    const response = { nodes: [{ id: nodeId }] };
+
+    mockAdminTemplatesService.listNodes.mockResolvedValue(response);
+
+    const result = await controller.listNodes({ templateId });
+
+    expect(mockAdminTemplatesService.listNodes).toHaveBeenCalledWith(templateId);
+    expect(result).toEqual(response);
+  });
+
   it('delegates node updates with path params and body dto', async () => {
-    const dto = { posX: 120 };
-    const response = { id: nodeId, posX: 120 };
+    const dto = { name: 'Updated HTTP APIs' };
+    const response = { id: nodeId, name: dto.name };
 
     mockAdminTemplatesService.updateNode.mockResolvedValue(response);
 
@@ -181,6 +191,7 @@ describe('AdminTemplatesController access', () => {
     deleteNode: jest.fn(),
     deleteTemplate: jest.fn(),
     getTemplate: jest.fn(),
+    listNodes: jest.fn(),
     listTemplates: jest.fn(),
     updateNode: jest.fn(),
     updateTemplate: jest.fn(),

--- a/apps/api/test/unit/templates/admin-templates.controller.spec.ts
+++ b/apps/api/test/unit/templates/admin-templates.controller.spec.ts
@@ -23,6 +23,8 @@ describe('AdminTemplatesController', () => {
     createTemplate: jest.fn(),
     deleteNode: jest.fn(),
     deleteTemplate: jest.fn(),
+    getTemplate: jest.fn(),
+    listTemplates: jest.fn(),
     updateNode: jest.fn(),
     updateTemplate: jest.fn(),
   };
@@ -65,6 +67,34 @@ describe('AdminTemplatesController', () => {
     const result = await controller.create(dto);
 
     expect(mockAdminTemplatesService.createTemplate).toHaveBeenCalledWith(dto);
+    expect(result).toEqual(response);
+  });
+
+  it('delegates template listing with query dto', async () => {
+    const query = {
+      page: 1,
+      perPage: 20,
+      q: 'backend',
+      roleCategory: RoleCategory.WEB_DEVELOPMENT,
+    };
+    const response = { data: [], meta: { page: 1, perPage: 20, total: 0, totalPages: 0 } };
+
+    mockAdminTemplatesService.listTemplates.mockResolvedValue(response);
+
+    const result = await controller.list(query);
+
+    expect(mockAdminTemplatesService.listTemplates).toHaveBeenCalledWith(query);
+    expect(result).toEqual(response);
+  });
+
+  it('delegates template reads with path params', async () => {
+    const response = { id: templateId, title: 'Backend Template' };
+
+    mockAdminTemplatesService.getTemplate.mockResolvedValue(response);
+
+    const result = await controller.get({ templateId });
+
+    expect(mockAdminTemplatesService.getTemplate).toHaveBeenCalledWith(templateId);
     expect(result).toEqual(response);
   });
 
@@ -150,6 +180,8 @@ describe('AdminTemplatesController access', () => {
     createTemplate: jest.fn().mockResolvedValue(response),
     deleteNode: jest.fn(),
     deleteTemplate: jest.fn(),
+    getTemplate: jest.fn(),
+    listTemplates: jest.fn(),
     updateNode: jest.fn(),
     updateTemplate: jest.fn(),
   };

--- a/apps/api/test/unit/templates/admin-templates.service.spec.ts
+++ b/apps/api/test/unit/templates/admin-templates.service.spec.ts
@@ -14,6 +14,7 @@ import {
   TemplateNodeInvalidValueException,
 } from '@/common/exceptions/app.exceptions';
 import { PrismaService } from '@/modules/prisma/prisma.service';
+import { DagreLayoutService } from '@/modules/roadmaps/services/dagre-layout.service';
 import { AdminTemplatesService } from '@/modules/templates/admin-templates.service';
 
 type AsyncMock<TResult = unknown, TArgs extends unknown[] = unknown[]> = jest.Mock<
@@ -67,10 +68,13 @@ interface AdminTemplatesPrismaMock {
     update: AsyncMock<TemplateRoadmapRecord>;
   };
   roadmapNode: {
+    count: AsyncMock<number>;
     create: AsyncMock<TemplateNodeRecord>;
     deleteMany: AsyncMock<{ count: number }>;
+    findMany: AsyncMock<TemplateNodeRecord[]>;
     findFirst: AsyncMock<{ id: string; nodeType?: NodeType } | TemplateNodeRecord | null>;
     update: AsyncMock<TemplateNodeRecord>;
+    updateMany: AsyncMock<{ count: number }>;
   };
   skill: {
     findUnique: AsyncMock<{ id: string; roleCategory: RoleCategory | null } | null>;
@@ -172,13 +176,16 @@ const createPrismaMock = (txMock: TxMock): AdminTemplatesPrismaMock => ({
     update: jest.fn<Promise<TemplateRoadmapRecord>, unknown[]>(),
   },
   roadmapNode: {
+    count: jest.fn<Promise<number>, unknown[]>().mockResolvedValue(0),
     create: jest.fn<Promise<TemplateNodeRecord>, unknown[]>(),
     deleteMany: jest.fn<Promise<{ count: number }>, unknown[]>(),
+    findMany: jest.fn<Promise<TemplateNodeRecord[]>, unknown[]>().mockResolvedValue([]),
     findFirst: jest.fn<
       Promise<{ id: string; nodeType?: NodeType } | TemplateNodeRecord | null>,
       unknown[]
     >(),
     update: jest.fn<Promise<TemplateNodeRecord>, unknown[]>(),
+    updateMany: jest.fn<Promise<{ count: number }>, unknown[]>().mockResolvedValue({ count: 1 }),
   },
   skill: {
     findUnique: jest.fn<
@@ -192,14 +199,27 @@ describe('AdminTemplatesService', () => {
   let service: AdminTemplatesService;
   let prisma: AdminTemplatesPrismaMock;
   let txMock: TxMock;
+  let dagreLayout: jest.Mocked<Pick<DagreLayoutService, 'computeLayout'>>;
 
   beforeEach(async () => {
     txMock = makeTxMock();
     const prismaMock = createPrismaMock(txMock);
+    dagreLayout = {
+      computeLayout: jest.fn(
+        (nodes: Parameters<DagreLayoutService['computeLayout']>[0]) =>
+          new Map(
+            nodes.map((node, index) => [node.tempId, { posX: index * 100, posY: index * 50 }]),
+          ),
+      ),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminTemplatesService,
+        {
+          provide: DagreLayoutService,
+          useValue: dagreLayout,
+        },
         {
           provide: PrismaService,
           useValue: prismaMock,
@@ -372,6 +392,35 @@ describe('AdminTemplatesService', () => {
       prisma.roadmap.findFirst.mockResolvedValue(makeTemplate());
     });
 
+    it('lists nodes for a template in persisted layout order', async () => {
+      const group = makeNode({
+        estimatedHours: null,
+        id: parentId,
+        name: 'Foundations',
+        nodeType: NodeType.GROUP,
+        parentId: null,
+        skillId: null,
+      });
+      const leaf = makeNode();
+
+      prisma.roadmapNode.findMany.mockResolvedValue([group, leaf]);
+
+      const result = await service.listNodes(templateId);
+
+      expect(prisma.roadmapNode.findMany).toHaveBeenCalledWith({
+        orderBy: [{ posY: 'asc' }, { posX: 'asc' }, { id: 'asc' }],
+        select: expectAnyObject(),
+        where: {
+          roadmap: { isTemplate: true },
+          roadmapId: templateId,
+        },
+      });
+      expect(result.nodes).toEqual([
+        expect.objectContaining({ id: parentId, nodeType: NodeType.GROUP }),
+        expect.objectContaining({ id: nodeId, nodeType: NodeType.REQUIRED }),
+      ]);
+    });
+
     it('creates a group node without parent, skill, description, or hours', async () => {
       const group = makeNode({
         estimatedHours: null,
@@ -383,12 +432,12 @@ describe('AdminTemplatesService', () => {
       });
 
       prisma.roadmapNode.create.mockResolvedValue(group);
+      prisma.roadmapNode.findMany.mockResolvedValue([group]);
+      prisma.roadmapNode.findFirst.mockResolvedValue(group);
 
       const result = await service.createNode(templateId, {
         name: 'Foundations',
         nodeType: NodeType.GROUP,
-        posX: 0,
-        posY: 0,
       });
 
       expect(prisma.roadmapNode.create).toHaveBeenCalledWith({
@@ -405,14 +454,42 @@ describe('AdminTemplatesService', () => {
         },
         select: expectAnyObject(),
       });
+      expect(dagreLayout.computeLayout).toHaveBeenCalledWith([
+        expect.objectContaining({
+          nodeType: NodeType.GROUP,
+          realId: parentId,
+          tempId: parentId,
+        }),
+      ]);
+      expect(prisma.roadmapNode.updateMany).toHaveBeenCalledWith({
+        data: {
+          posX: 0,
+          posY: 0,
+        },
+        where: {
+          id: parentId,
+          roadmapId: templateId,
+        },
+      });
       expect(prisma.skill.findUnique).not.toHaveBeenCalled();
       expect(result.nodeType).toBe(NodeType.GROUP);
     });
 
-    it('creates a leaf node when parent is a same-template group and skill exists', async () => {
+    it('creates a leaf node when parent is a same-template section and skill exists', async () => {
+      const group = makeNode({
+        estimatedHours: null,
+        id: parentId,
+        name: 'Foundations',
+        nodeType: NodeType.MILESTONE,
+        parentId: null,
+        skillId: null,
+      });
       const node = makeNode();
 
-      prisma.roadmapNode.findFirst.mockResolvedValue({ id: parentId });
+      prisma.roadmapNode.findFirst
+        .mockResolvedValueOnce({ id: parentId })
+        .mockResolvedValueOnce(node);
+      prisma.roadmapNode.findMany.mockResolvedValue([group, node]);
       prisma.skill.findUnique.mockResolvedValue({
         id: skillId,
         roleCategory: RoleCategory.WEB_DEVELOPMENT,
@@ -424,8 +501,6 @@ describe('AdminTemplatesService', () => {
         name: 'HTTP APIs',
         nodeType: NodeType.REQUIRED,
         parentId,
-        posX: 100,
-        posY: 200,
         skillId,
       });
 
@@ -433,7 +508,7 @@ describe('AdminTemplatesService', () => {
         select: { id: true },
         where: {
           id: parentId,
-          nodeType: NodeType.GROUP,
+          nodeType: { in: [NodeType.GROUP, NodeType.MILESTONE] },
           roadmap: { isTemplate: true },
           roadmapId: templateId,
         },
@@ -447,41 +522,44 @@ describe('AdminTemplatesService', () => {
 
     it('updates nodes after merging existing state with the dto', async () => {
       const existing = makeNode();
-      const updated = makeNode({ posX: 120 });
+      const updated = makeNode({ estimatedHours: 7 });
+      const relaid = makeNode({ estimatedHours: 7, posX: 0, posY: 0 });
 
       prisma.roadmapNode.findFirst
         .mockResolvedValueOnce(existing)
-        .mockResolvedValueOnce({ id: parentId });
+        .mockResolvedValueOnce({ id: parentId })
+        .mockResolvedValueOnce(relaid);
+      prisma.roadmapNode.findMany.mockResolvedValue([updated]);
       prisma.skill.findUnique.mockResolvedValue({
         id: skillId,
         roleCategory: RoleCategory.WEB_DEVELOPMENT,
       });
       prisma.roadmapNode.update.mockResolvedValue(updated);
 
-      const result = await service.updateNode(templateId, nodeId, { posX: 120 });
+      const result = await service.updateNode(templateId, nodeId, { estimatedHours: 7 });
 
       expect(prisma.roadmapNode.update).toHaveBeenCalledWith({
-        data: { posX: 120 },
+        data: { estimatedHours: 7 },
         select: expectAnyObject(),
         where: { id: nodeId },
       });
-      expect(result.posX).toBe(120);
+      expect(dagreLayout.computeLayout).toHaveBeenCalledTimes(1);
+      expect(result.estimatedHours).toBe(7);
+      expect(result.posX).toBe(0);
     });
 
     it('throws RoadmapNodeNotFoundException when updating a missing node', async () => {
       prisma.roadmapNode.findFirst.mockResolvedValue(null);
 
-      await expect(service.updateNode(templateId, nodeId, { posX: 100 })).rejects.toThrow(
-        RoadmapNodeNotFoundException,
-      );
+      await expect(
+        service.updateNode(templateId, nodeId, { name: 'Missing Node' }),
+      ).rejects.toThrow(RoadmapNodeNotFoundException);
     });
 
     it('rejects invalid group and milestone node shapes', async () => {
       const groupPromise = service.createNode(templateId, {
         name: 'Bad Group',
         nodeType: NodeType.GROUP,
-        posX: 0,
-        posY: 0,
         skillId,
       });
 
@@ -493,8 +571,6 @@ describe('AdminTemplatesService', () => {
           estimatedHours: 1,
           name: 'Bad Milestone',
           nodeType: NodeType.MILESTONE,
-          posX: 0,
-          posY: 0,
         }),
       ).rejects.toThrow(TemplateNodeInvalidShapeException);
     });
@@ -503,8 +579,6 @@ describe('AdminTemplatesService', () => {
       const missingParentPromise = service.createNode(templateId, {
         name: 'No Parent',
         nodeType: NodeType.REQUIRED,
-        posX: 0,
-        posY: 0,
         skillId,
       });
 
@@ -516,13 +590,11 @@ describe('AdminTemplatesService', () => {
           name: 'No Skill',
           nodeType: NodeType.OPTIONAL,
           parentId,
-          posX: 0,
-          posY: 0,
         }),
       ).rejects.toThrow(TemplateNodeInvalidReferenceException);
     });
 
-    it('rejects invalid, cross-template, and non-group parents', async () => {
+    it('rejects invalid, cross-template, and non-section parents', async () => {
       prisma.roadmapNode.findFirst.mockResolvedValue(null);
 
       await expect(
@@ -530,8 +602,6 @@ describe('AdminTemplatesService', () => {
           name: 'Bad Parent',
           nodeType: NodeType.REQUIRED,
           parentId: otherTemplateId,
-          posX: 0,
-          posY: 0,
           skillId,
         }),
       ).rejects.toThrow(TemplateNodeInvalidReferenceException);
@@ -546,8 +616,6 @@ describe('AdminTemplatesService', () => {
           name: 'Unknown Skill',
           nodeType: NodeType.REQUIRED,
           parentId,
-          posX: 0,
-          posY: 0,
           skillId,
         }),
       ).rejects.toThrow(SkillNotFoundException);
@@ -565,19 +633,24 @@ describe('AdminTemplatesService', () => {
           name: 'Wrong Skill',
           nodeType: NodeType.REQUIRED,
           parentId,
-          posX: 0,
-          posY: 0,
           skillId,
         }),
       ).rejects.toThrow(TemplateNodeInvalidReferenceException);
     });
 
-    it('rejects bad layout values at the service layer', async () => {
+    it('rejects bad estimated hour values at the service layer', async () => {
+      prisma.roadmapNode.findFirst.mockResolvedValue({ id: parentId });
+      prisma.skill.findUnique.mockResolvedValue({
+        id: skillId,
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      });
+
       const promise = service.createNode(templateId, {
+        estimatedHours: Number.NaN,
         name: 'Bad Layout',
-        nodeType: NodeType.GROUP,
-        posX: Number.NaN,
-        posY: 0,
+        nodeType: NodeType.REQUIRED,
+        parentId,
+        skillId,
       });
 
       await expect(promise).rejects.toThrow(TemplateNodeInvalidValueException);
@@ -610,16 +683,16 @@ describe('AdminTemplatesService', () => {
       expect(txMock.roadmapNode.deleteMany).toHaveBeenNthCalledWith(2, {
         where: {
           id: parentId,
-          nodeType: NodeType.GROUP,
+          nodeType: { in: [NodeType.GROUP, NodeType.MILESTONE] },
           roadmapId: templateId,
         },
       });
     });
 
-    it('deletes non-group nodes without deleting siblings', async () => {
+    it('deletes leaf nodes without deleting siblings', async () => {
       prisma.roadmapNode.findFirst.mockResolvedValue({
         id: nodeId,
-        nodeType: NodeType.MILESTONE,
+        nodeType: NodeType.REQUIRED,
       });
       prisma.roadmapNode.deleteMany.mockResolvedValue({ count: 1 });
 

--- a/apps/api/test/unit/templates/admin-templates.service.spec.ts
+++ b/apps/api/test/unit/templates/admin-templates.service.spec.ts
@@ -59,8 +59,10 @@ interface TxMock {
 interface AdminTemplatesPrismaMock {
   $transaction: AsyncMock<unknown, [unknown]>;
   roadmap: {
+    count: AsyncMock<number>;
     create: AsyncMock<TemplateRoadmapRecord>;
     deleteMany: AsyncMock<{ count: number }>;
+    findMany: AsyncMock<TemplateRoadmapRecord[]>;
     findFirst: AsyncMock<TemplateRoadmapRecord | null>;
     update: AsyncMock<TemplateRoadmapRecord>;
   };
@@ -162,8 +164,10 @@ const createPrismaMock = (txMock: TxMock): AdminTemplatesPrismaMock => ({
     return callback(txMock);
   }),
   roadmap: {
+    count: jest.fn<Promise<number>, unknown[]>(),
     create: jest.fn<Promise<TemplateRoadmapRecord>, unknown[]>(),
     deleteMany: jest.fn<Promise<{ count: number }>, unknown[]>(),
+    findMany: jest.fn<Promise<TemplateRoadmapRecord[]>, unknown[]>(),
     findFirst: jest.fn<Promise<TemplateRoadmapRecord | null>, unknown[]>(),
     update: jest.fn<Promise<TemplateRoadmapRecord>, unknown[]>(),
   },
@@ -212,6 +216,57 @@ describe('AdminTemplatesService', () => {
   });
 
   describe('templates', () => {
+    it('lists admin templates without requiring template nodes', async () => {
+      const emptyTemplate = makeTemplate({
+        id: 'empty-template',
+        title: 'Empty Backend Template',
+      });
+
+      prisma.roadmap.findMany.mockResolvedValue([emptyTemplate]);
+      prisma.roadmap.count.mockResolvedValue(1);
+
+      const result = await service.listTemplates({
+        page: 1,
+        perPage: 10,
+        q: 'Backend',
+        roleCategory: RoleCategory.WEB_DEVELOPMENT,
+      });
+
+      expect(prisma.roadmap.findMany).toHaveBeenCalledWith({
+        orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
+        select: expectAnyObject(),
+        skip: 0,
+        take: 10,
+        where: {
+          isTemplate: true,
+          roleCategory: RoleCategory.WEB_DEVELOPMENT,
+          title: {
+            contains: 'Backend',
+            mode: 'insensitive',
+          },
+        },
+      });
+      expect(prisma.roadmap.count).toHaveBeenCalledWith({
+        where: {
+          isTemplate: true,
+          roleCategory: RoleCategory.WEB_DEVELOPMENT,
+          title: {
+            contains: 'Backend',
+            mode: 'insensitive',
+          },
+        },
+      });
+      expect(result).toEqual({
+        data: [expect.objectContaining({ id: 'empty-template', title: 'Empty Backend Template' })],
+        meta: {
+          page: 1,
+          perPage: 10,
+          total: 1,
+          totalPages: 1,
+        },
+      });
+    });
+
     it('creates templates with personal roadmap fields forced to null', async () => {
       const template = makeTemplate({ estimatedWeeks: null });
 
@@ -242,15 +297,38 @@ describe('AdminTemplatesService', () => {
       expect(result.userId).toBeNull();
     });
 
-    it('updates template metadata without changing role category', async () => {
+    it('reads a template by id', async () => {
       const template = makeTemplate();
-      const updated = makeTemplate({ estimatedWeeks: null, title: 'Updated Template' });
+
+      prisma.roadmap.findFirst.mockResolvedValue(template);
+
+      const result = await service.getTemplate(templateId);
+
+      expect(prisma.roadmap.findFirst).toHaveBeenCalledWith({
+        select: expectAnyObject(),
+        where: { id: templateId, isTemplate: true },
+      });
+      expect(result).toMatchObject({
+        id: templateId,
+        isTemplate: true,
+        title: template.title,
+      });
+    });
+
+    it('updates template metadata including role category', async () => {
+      const template = makeTemplate();
+      const updated = makeTemplate({
+        estimatedWeeks: null,
+        roleCategory: RoleCategory.DEVOPS,
+        title: 'Updated Template',
+      });
 
       prisma.roadmap.findFirst.mockResolvedValue(template);
       prisma.roadmap.update.mockResolvedValue(updated);
 
       const result = await service.updateTemplate(templateId, {
         estimatedWeeks: null,
+        roleCategory: RoleCategory.DEVOPS,
         title: 'Updated Template',
       });
 
@@ -261,6 +339,7 @@ describe('AdminTemplatesService', () => {
       expect(prisma.roadmap.update).toHaveBeenCalledWith({
         data: {
           estimatedWeeks: null,
+          roleCategory: RoleCategory.DEVOPS,
           title: 'Updated Template',
         },
         select: expectAnyObject(),
@@ -268,6 +347,7 @@ describe('AdminTemplatesService', () => {
       });
       expect(result.title).toBe('Updated Template');
       expect(result.estimatedWeeks).toBeNull();
+      expect(result.roleCategory).toBe(RoleCategory.DEVOPS);
     });
 
     it('deletes only template roadmaps', async () => {

--- a/apps/api/test/unit/users/users.controller.spec.ts
+++ b/apps/api/test/unit/users/users.controller.spec.ts
@@ -2,7 +2,7 @@
 import type { TestingModule } from '@nestjs/testing';
 
 import { Test } from '@nestjs/testing';
-import { OAuthProvider } from '@repo/db/prisma/client';
+import { OAuthProvider, UserRole } from '@repo/db/prisma/client';
 
 import { UsersController } from '@/modules/users/users.controller';
 import { UsersService } from '@/modules/users/users.service';
@@ -58,6 +58,20 @@ describe('UsersController', () => {
         role: 'user',
         createdAt: new Date('2025-04-24T07:00:00Z'),
       });
+    });
+
+    it('should serialize an admin role as lowercase admin', () => {
+      const mockUser = {
+        id: '1',
+        email: 'admin@example.com',
+        fullName: 'Admin User',
+        role: UserRole.ADMIN,
+        createdAt: new Date('2025-04-24T07:00:00Z'),
+      };
+
+      const result = controller.getMe(mockUser);
+
+      expect(result.role).toBe('admin');
     });
   });
 

--- a/apps/web/app/(admin)/admin/_components/admin-navigation.tsx
+++ b/apps/web/app/(admin)/admin/_components/admin-navigation.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { Route } from 'next';
+
+import { Button } from '@repo/design-system/components/ui/button';
+import { cn } from '@repo/design-system/lib/utils';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const ADMIN_NAV_ITEMS = [
+  {
+    href: '/admin/skills',
+    label: 'Skills and resources',
+  },
+  {
+    href: '/admin/templates',
+    label: 'Templates',
+  },
+] as const;
+
+export function AdminNavigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-col gap-1" aria-label="Admin navigation">
+      {ADMIN_NAV_ITEMS.map((item) => {
+        const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+        return (
+          <Button
+            key={item.href}
+            variant={isActive ? 'secondary' : 'ghost'}
+            className={cn('justify-start rounded-2xl', isActive && 'pointer-events-none')}
+            render={<Link href={item.href as Route<string>}>{item.label}</Link>}
+          />
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/app/(admin)/admin/_components/admin-navigation.tsx
+++ b/apps/web/app/(admin)/admin/_components/admin-navigation.tsx
@@ -2,6 +2,8 @@
 
 import type { Route } from 'next';
 
+import { Book02Icon, ListTreeIcon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
 import { Button } from '@repo/design-system/components/ui/button';
 import { cn } from '@repo/design-system/lib/utils';
 import Link from 'next/link';
@@ -10,10 +12,12 @@ import { usePathname } from 'next/navigation';
 const ADMIN_NAV_ITEMS = [
   {
     href: '/admin/skills',
+    icon: Book02Icon,
     label: 'Skills and resources',
   },
   {
     href: '/admin/templates',
+    icon: ListTreeIcon,
     label: 'Templates',
   },
 ] as const;
@@ -22,19 +26,35 @@ export function AdminNavigation() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex flex-col gap-1" aria-label="Admin navigation">
-      {ADMIN_NAV_ITEMS.map((item) => {
-        const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+    <nav
+      className="border-border/70 bg-background/75 shadow-primary/10 fixed inset-x-3 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-40 mx-auto max-w-xl rounded-3xl border p-2 shadow-lg backdrop-blur-xl"
+      aria-label="Admin navigation"
+    >
+      <div className="flex gap-2">
+        {ADMIN_NAV_ITEMS.map((item) => {
+          const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
 
-        return (
-          <Button
-            key={item.href}
-            variant={isActive ? 'secondary' : 'ghost'}
-            className={cn('justify-start rounded-2xl', isActive && 'pointer-events-none')}
-            render={<Link href={item.href as Route<string>}>{item.label}</Link>}
-          />
-        );
-      })}
+          return (
+            <Button
+              key={item.href}
+              variant={isActive ? 'secondary' : 'ghost'}
+              className={cn(
+                'h-11 flex-1 justify-center rounded-2xl px-3 text-xs sm:text-sm',
+                isActive && 'pointer-events-none',
+              )}
+              render={
+                <Link
+                  href={item.href as Route<string>}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  <HugeiconsIcon data-icon="inline-start" icon={item.icon} />
+                  <span className="truncate">{item.label}</span>
+                </Link>
+              }
+            />
+          );
+        })}
+      </div>
     </nav>
   );
 }

--- a/apps/web/app/(admin)/admin/layout.tsx
+++ b/apps/web/app/(admin)/admin/layout.tsx
@@ -63,7 +63,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
             <AdminNavigation />
             <Separator className="my-3" />
             <p className="text-muted-foreground px-2 text-xs leading-5">
-              Template graph editing is intentionally excluded from Phase 2.
+              Visual template graph editing remains intentionally deferred.
             </p>
           </aside>
 

--- a/apps/web/app/(admin)/admin/layout.tsx
+++ b/apps/web/app/(admin)/admin/layout.tsx
@@ -10,6 +10,8 @@ import { redirect } from 'next/navigation';
 
 import { authServerData } from '@/server-fetcher/auth-server';
 
+import { AdminNavigation } from './_components/admin-navigation';
+
 export const metadata: Metadata = {
   title: 'Admin Console - RMap',
   description: 'Manage RMap content catalogs and roadmap templates.',
@@ -58,20 +60,10 @@ export default async function AdminLayout({ children }: { children: ReactNode })
 
         <div className="grid flex-1 gap-4 py-4 lg:grid-cols-[240px_minmax(0,1fr)]">
           <aside className="border-border/70 bg-card/85 h-fit rounded-3xl border p-3 shadow-sm backdrop-blur-md">
-            <nav className="flex flex-col gap-1" aria-label="Admin navigation">
-              <Button
-                variant="secondary"
-                className="justify-start rounded-2xl"
-                render={<Link href={'/admin/skills' as Route<string>}>Skills and resources</Link>}
-              />
-              <Button variant="ghost" className="justify-start rounded-2xl" disabled>
-                Templates
-                <span className="text-muted-foreground ml-auto text-xs">Phase 2</span>
-              </Button>
-            </nav>
+            <AdminNavigation />
             <Separator className="my-3" />
             <p className="text-muted-foreground px-2 text-xs leading-5">
-              Template graph editing is intentionally excluded from Phase 1.
+              Template graph editing is intentionally excluded from Phase 2.
             </p>
           </aside>
 

--- a/apps/web/app/(admin)/admin/layout.tsx
+++ b/apps/web/app/(admin)/admin/layout.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next';
+import type { Route } from 'next';
+import type { ReactNode } from 'react';
+
+import { Badge } from '@repo/design-system/components/ui/badge';
+import { Button } from '@repo/design-system/components/ui/button';
+import { Separator } from '@repo/design-system/components/ui/separator';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+
+import { authServerData } from '@/server-fetcher/auth-server';
+
+export const metadata: Metadata = {
+  title: 'Admin Console - RMap',
+  description: 'Manage RMap content catalogs and roadmap templates.',
+};
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const user = await authServerData.getInitialUser();
+
+  if (!user) {
+    redirect('/sign-in?callbackUrl=/admin');
+  }
+
+  if (user.role !== 'ADMIN') {
+    redirect('/dashboard');
+  }
+
+  return (
+    <div className="bg-background relative min-h-screen overflow-hidden">
+      <div
+        className="pointer-events-none absolute inset-0 opacity-80"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--primary) 14%, transparent), transparent 30%), radial-gradient(circle at 88% 0%, color-mix(in srgb, var(--chart-2) 16%, transparent), transparent 24%), linear-gradient(135deg, var(--background), var(--muted))',
+        }}
+      />
+      <div className="relative mx-auto flex min-h-screen w-full max-w-360 flex-col px-4 py-4 sm:px-6 lg:px-8">
+        <header className="border-border/70 bg-background/80 flex flex-col gap-4 rounded-3xl border p-4 shadow-sm backdrop-blur-md lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex min-w-0 flex-col gap-1">
+            <Link className="font-heading text-foreground w-fit text-2xl font-bold" href="/">
+              RMap Admin
+            </Link>
+            <p className="text-muted-foreground text-sm">
+              Course content operations for skills, resources, and templates.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{user.fullName}</Badge>
+            <Button
+              variant="outline"
+              size="sm"
+              render={<Link href={'/dashboard' as Route<string>}>Back to app</Link>}
+            />
+          </div>
+        </header>
+
+        <div className="grid flex-1 gap-4 py-4 lg:grid-cols-[240px_minmax(0,1fr)]">
+          <aside className="border-border/70 bg-card/85 h-fit rounded-3xl border p-3 shadow-sm backdrop-blur-md">
+            <nav className="flex flex-col gap-1" aria-label="Admin navigation">
+              <Button
+                variant="secondary"
+                className="justify-start rounded-2xl"
+                render={<Link href={'/admin/skills' as Route<string>}>Skills and resources</Link>}
+              />
+              <Button variant="ghost" className="justify-start rounded-2xl" disabled>
+                Templates
+                <span className="text-muted-foreground ml-auto text-xs">Phase 2</span>
+              </Button>
+            </nav>
+            <Separator className="my-3" />
+            <p className="text-muted-foreground px-2 text-xs leading-5">
+              Template graph editing is intentionally excluded from Phase 1.
+            </p>
+          </aside>
+
+          <main className="min-w-0">{children}</main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(admin)/admin/layout.tsx
+++ b/apps/web/app/(admin)/admin/layout.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from 'react';
 
 import { Badge } from '@repo/design-system/components/ui/badge';
 import { Button } from '@repo/design-system/components/ui/button';
-import { Separator } from '@repo/design-system/components/ui/separator';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
@@ -61,10 +60,6 @@ export default async function AdminLayout({ children }: { children: ReactNode })
         <div className="grid flex-1 gap-4 py-4 lg:grid-cols-[240px_minmax(0,1fr)]">
           <aside className="border-border/70 bg-card/85 h-fit rounded-3xl border p-3 shadow-sm backdrop-blur-md">
             <AdminNavigation />
-            <Separator className="my-3" />
-            <p className="text-muted-foreground px-2 text-xs leading-5">
-              Visual template graph editing remains intentionally deferred.
-            </p>
           </aside>
 
           <main className="min-w-0">{children}</main>

--- a/apps/web/app/(admin)/admin/layout.tsx
+++ b/apps/web/app/(admin)/admin/layout.tsx
@@ -36,7 +36,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
             'radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--primary) 14%, transparent), transparent 30%), radial-gradient(circle at 88% 0%, color-mix(in srgb, var(--chart-2) 16%, transparent), transparent 24%), linear-gradient(135deg, var(--background), var(--muted))',
         }}
       />
-      <div className="relative mx-auto flex min-h-screen w-full max-w-360 flex-col px-4 py-4 sm:px-6 lg:px-8">
+      <div className="relative mx-auto flex min-h-screen w-full max-w-360 flex-col px-4 pt-4 pb-[calc(7rem+env(safe-area-inset-bottom))] sm:px-6 lg:px-8">
         <header className="border-border/70 bg-background/80 flex flex-col gap-4 rounded-3xl border p-4 shadow-sm backdrop-blur-md lg:flex-row lg:items-center lg:justify-between">
           <div className="flex min-w-0 flex-col gap-1">
             <Link className="font-heading text-foreground w-fit text-2xl font-bold" href="/">
@@ -57,13 +57,8 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           </div>
         </header>
 
-        <div className="grid flex-1 gap-4 py-4 lg:grid-cols-[240px_minmax(0,1fr)]">
-          <aside className="border-border/70 bg-card/85 h-fit rounded-3xl border p-3 shadow-sm backdrop-blur-md">
-            <AdminNavigation />
-          </aside>
-
-          <main className="min-w-0">{children}</main>
-        </div>
+        <main className="min-w-0 flex-1 py-4">{children}</main>
+        <AdminNavigation />
       </div>
     </div>
   );

--- a/apps/web/app/(admin)/admin/page.tsx
+++ b/apps/web/app/(admin)/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AdminIndexPage() {
+  redirect('/admin/skills');
+}

--- a/apps/web/app/(admin)/admin/skills/_components/admin-skills-content.tsx
+++ b/apps/web/app/(admin)/admin/skills/_components/admin-skills-content.tsx
@@ -1,0 +1,1058 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@repo/design-system/components/ui/alert-dialog';
+import { Badge } from '@repo/design-system/components/ui/badge';
+import { Button } from '@repo/design-system/components/ui/button';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@repo/design-system/components/ui/card';
+import { Checkbox } from '@repo/design-system/components/ui/checkbox';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@repo/design-system/components/ui/drawer';
+import { Field, FieldError, FieldGroup, FieldLabel } from '@repo/design-system/components/ui/field';
+import { Input } from '@repo/design-system/components/ui/input';
+import { Separator } from '@repo/design-system/components/ui/separator';
+import { Skeleton } from '@repo/design-system/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@repo/design-system/components/ui/table';
+import { toast } from '@repo/design-system/lib/toast';
+import { cn } from '@repo/design-system/lib/utils';
+import { useDeferredValue, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import type {
+  AdminSkill,
+  AdminSkillPayload,
+  AdminSkillResource,
+  AdminSkillResourcePayload,
+  AdminSkillsListResponse,
+  ResourceType,
+  RoleCategory,
+} from '@/types/admin-content';
+
+import { adminContentService, getApiErrorMessage } from '@/services/admin-content.service';
+import {
+  adminResourceFormSchema,
+  adminSkillFormSchema,
+  RESOURCE_TYPE_VALUES,
+  ROLE_CATEGORY_VALUES,
+  type AdminResourceFormValues,
+  type AdminSkillFormValues,
+} from '@/validations/admin-content.schema';
+
+const PER_PAGE = 10;
+const EMPTY_SKILLS: AdminSkill[] = [];
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
+
+const CONTROL_CLASS_NAME =
+  'border-border focus-visible:border-border bg-background text-foreground disabled:border-disabled disabled:bg-background disabled:text-disabled disabled:placeholder:text-disabled placeholder:text-muted-foreground/70 focus-visible:ring-ring min-h-10 w-full min-w-0 rounded-md border px-3 py-2.5 text-base shadow-[0_1px_2px_0_rgba(139,92,246,0.10)] transition-all outline-none focus-visible:shadow-none focus-visible:ring-2 disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20';
+
+type RoleFilter = '' | RoleCategory;
+
+type SkillDrawerState =
+  | {
+      mode: 'create';
+      skill?: undefined;
+    }
+  | {
+      mode: 'edit';
+      skill: AdminSkill;
+    };
+
+type ResourceDrawerState =
+  | {
+      mode: 'create';
+      resource?: undefined;
+    }
+  | {
+      mode: 'edit';
+      resource: AdminSkillResource;
+    };
+
+export function AdminSkillsContent() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>('');
+  const [page, setPage] = useState(1);
+  const [skillsResponse, setSkillsResponse] = useState<AdminSkillsListResponse | null>(null);
+  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
+  const [resources, setResources] = useState<AdminSkillResource[]>([]);
+  const [isLoadingSkills, setIsLoadingSkills] = useState(true);
+  const [isLoadingResources, setIsLoadingResources] = useState(false);
+  const [skillsError, setSkillsError] = useState<string | null>(null);
+  const [resourcesError, setResourcesError] = useState<string | null>(null);
+  const [skillsRefreshKey, setSkillsRefreshKey] = useState(0);
+  const [resourcesRefreshKey, setResourcesRefreshKey] = useState(0);
+  const [skillDrawer, setSkillDrawer] = useState<SkillDrawerState | null>(null);
+  const [resourceDrawer, setResourceDrawer] = useState<ResourceDrawerState | null>(null);
+  const [skillToDelete, setSkillToDelete] = useState<AdminSkill | null>(null);
+  const [resourceToDelete, setResourceToDelete] = useState<AdminSkillResource | null>(null);
+  const [isDeletingSkill, setIsDeletingSkill] = useState(false);
+  const [isDeletingResource, setIsDeletingResource] = useState(false);
+  const deferredSearchTerm = useDeferredValue(searchTerm.trim());
+
+  const skills = skillsResponse?.data ?? EMPTY_SKILLS;
+  const skillsMeta = skillsResponse?.meta;
+  const selectedSkill = skills.find((skill) => skill.id === selectedSkillId) ?? null;
+  const primaryResourceCount = resources.filter((resource) => resource.isPrimary).length;
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    setIsLoadingSkills(true);
+    setSkillsError(null);
+
+    void adminContentService
+      .listSkills({
+        page,
+        perPage: PER_PAGE,
+        q: deferredSearchTerm || undefined,
+        roleCategory: roleFilter || undefined,
+      })
+      .then((response) => {
+        if (!isCurrent) return;
+        setSkillsResponse(response);
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) return;
+        setSkillsResponse(null);
+        setSkillsError(getApiErrorMessage(error, 'Unable to load skills.'));
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingSkills(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [deferredSearchTerm, page, roleFilter, skillsRefreshKey]);
+
+  useEffect(() => {
+    if (skills.length === 0) {
+      setSelectedSkillId(null);
+      return;
+    }
+
+    if (!selectedSkillId || !skills.some((skill) => skill.id === selectedSkillId)) {
+      setSelectedSkillId(skills[0]?.id ?? null);
+    }
+  }, [selectedSkillId, skills]);
+
+  useEffect(() => {
+    if (!selectedSkillId) {
+      setResources([]);
+      setResourcesError(null);
+      return;
+    }
+
+    let isCurrent = true;
+
+    setIsLoadingResources(true);
+    setResourcesError(null);
+
+    void adminContentService
+      .listResources(selectedSkillId)
+      .then((response) => {
+        if (!isCurrent) return;
+        setResources(response.resources);
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) return;
+        setResources([]);
+        setResourcesError(getApiErrorMessage(error, 'Unable to load resources.'));
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingResources(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [resourcesRefreshKey, selectedSkillId]);
+
+  const refreshSkills = () => {
+    setSkillsRefreshKey((current) => current + 1);
+  };
+
+  const refreshResources = () => {
+    setResourcesRefreshKey((current) => current + 1);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    setPage(1);
+  };
+
+  const handleRoleFilterChange = (value: RoleFilter) => {
+    setRoleFilter(value);
+    setPage(1);
+  };
+
+  const handleSubmitSkill = async (payload: AdminSkillPayload, skill?: AdminSkill) => {
+    const savedSkill = skill
+      ? await adminContentService.updateSkill(skill.id, payload)
+      : await adminContentService.createSkill(payload);
+
+    setSelectedSkillId(savedSkill.id);
+    refreshSkills();
+    toast.success(skill ? 'Skill updated' : 'Skill created');
+  };
+
+  const handleSubmitResource = async (
+    payload: AdminSkillResourcePayload,
+    resource?: AdminSkillResource,
+  ) => {
+    if (!selectedSkill) return;
+
+    if (resource) {
+      await adminContentService.updateResource(selectedSkill.id, resource.id, payload);
+      toast.success('Resource updated');
+    } else {
+      await adminContentService.createResource(selectedSkill.id, payload);
+      toast.success('Resource created');
+    }
+
+    refreshResources();
+  };
+
+  const handleDeleteSkill = async () => {
+    if (!skillToDelete) return;
+
+    setIsDeletingSkill(true);
+
+    try {
+      await adminContentService.deleteSkill(skillToDelete.id);
+      toast.success('Skill deleted');
+      setSkillToDelete(null);
+      refreshSkills();
+    } catch (error) {
+      toast.error('Skill deletion blocked', {
+        description: getApiErrorMessage(error, 'Unable to delete this skill.'),
+      });
+    } finally {
+      setIsDeletingSkill(false);
+    }
+  };
+
+  const handleDeleteResource = async () => {
+    if (!selectedSkill || !resourceToDelete) return;
+
+    setIsDeletingResource(true);
+
+    try {
+      await adminContentService.deleteResource(selectedSkill.id, resourceToDelete.id);
+      toast.success('Resource deleted');
+      setResourceToDelete(null);
+      refreshResources();
+    } catch (error) {
+      toast.error('Resource deletion failed', {
+        description: getApiErrorMessage(error, 'Unable to delete this resource.'),
+      });
+    } finally {
+      setIsDeletingResource(false);
+    }
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <section className="border-border/70 bg-card/90 rounded-3xl border p-5 shadow-sm backdrop-blur-md">
+        <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+          <div className="flex max-w-3xl flex-col gap-2">
+            <Badge variant="outline" className="w-fit">
+              Phase 1
+            </Badge>
+            <div className="flex flex-col gap-1">
+              <h1 className="font-heading text-foreground text-3xl leading-tight sm:text-4xl">
+                Skills and resources
+              </h1>
+              <p className="text-muted-foreground text-sm sm:text-base">
+                Manage course-scope skill records and keep resource lists scoped to the selected
+                skill.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => refreshSkills()}>
+              Refresh
+            </Button>
+            <Button onClick={() => setSkillDrawer({ mode: 'create' })}>Create skill</Button>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid min-w-0 gap-4 2xl:grid-cols-[minmax(0,1.25fr)_minmax(420px,0.75fr)]">
+        <Card className="bg-card/90 backdrop-blur-md">
+          <CardHeader>
+            <CardTitle>Skill catalog</CardTitle>
+            <CardDescription>
+              Search by name and filter by role category. Selecting a row loads its resources.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px]">
+              <Field>
+                <FieldLabel className="sr-only" htmlFor="skill-search">
+                  Search skills
+                </FieldLabel>
+                <Input
+                  id="skill-search"
+                  placeholder="Search skills..."
+                  value={searchTerm}
+                  onChange={(event) => handleSearchChange(event.target.value)}
+                />
+              </Field>
+              <Field>
+                <FieldLabel className="sr-only" htmlFor="role-filter">
+                  Filter by role category
+                </FieldLabel>
+                <NativeSelect
+                  id="role-filter"
+                  value={roleFilter}
+                  onChange={(event) => handleRoleFilterChange(event.target.value as RoleFilter)}
+                >
+                  <option value="">All role categories</option>
+                  {ROLE_CATEGORY_VALUES.map((category) => (
+                    <option key={category} value={category}>
+                      {formatEnumLabel(category)}
+                    </option>
+                  ))}
+                </NativeSelect>
+              </Field>
+            </div>
+
+            {skillsError ? (
+              <InlineNotice title="Skills unavailable" tone="error" description={skillsError} />
+            ) : null}
+
+            <div className="overflow-hidden rounded-2xl border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Hours</TableHead>
+                    <TableHead>Updated</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {isLoadingSkills ? (
+                    <TablePlaceholder rows={5} />
+                  ) : skills.length > 0 ? (
+                    skills.map((skill) => (
+                      <TableRow
+                        key={skill.id}
+                        className="cursor-pointer"
+                        data-state={skill.id === selectedSkillId ? 'selected' : undefined}
+                        onClick={() => setSelectedSkillId(skill.id)}
+                      >
+                        <TableCell className="min-w-64 whitespace-normal">
+                          <div className="flex flex-col gap-1">
+                            <span className="font-medium">{skill.name}</span>
+                            <span className="text-muted-foreground line-clamp-2 text-xs">
+                              {skill.description || 'No description yet.'}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">
+                            {skill.roleCategory ? formatEnumLabel(skill.roleCategory) : 'None'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{formatHours(skill.defaultEstimatedHours)}</TableCell>
+                        <TableCell>{formatDate(skill.updatedAt)}</TableCell>
+                        <TableCell>
+                          <div
+                            className="flex justify-end gap-2"
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setSkillDrawer({ mode: 'edit', skill })}
+                            >
+                              Edit
+                            </Button>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => setSkillToDelete(skill)}
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell className="text-muted-foreground h-32 text-center" colSpan={5}>
+                        No skills match the current filters.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-muted-foreground text-sm">
+                {skillsMeta
+                  ? `${skillsMeta.total} skills, page ${skillsMeta.page} of ${Math.max(skillsMeta.totalPages, 1)}`
+                  : 'Loading skills...'}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isLoadingSkills || page <= 1}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={
+                    isLoadingSkills ||
+                    !skillsMeta ||
+                    skillsMeta.totalPages === 0 ||
+                    page >= skillsMeta.totalPages
+                  }
+                  onClick={() => setPage((current) => current + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-card/90 backdrop-blur-md">
+          <CardHeader>
+            <CardTitle>Selected-skill resources</CardTitle>
+            <CardDescription>
+              Resources are loaded and mutated only for the selected skill.
+            </CardDescription>
+            <CardAction>
+              <Button
+                size="sm"
+                disabled={!selectedSkill}
+                onClick={() => setResourceDrawer({ mode: 'create' })}
+              >
+                Add resource
+              </Button>
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            {selectedSkill ? (
+              <div className="bg-muted/30 rounded-2xl border p-4">
+                <p className="text-muted-foreground text-xs tracking-[0.2em] uppercase">
+                  Selected skill
+                </p>
+                <div className="mt-2 flex flex-col gap-2">
+                  <h2 className="font-heading text-xl">{selectedSkill.name}</h2>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="secondary">
+                      {selectedSkill.roleCategory
+                        ? formatEnumLabel(selectedSkill.roleCategory)
+                        : 'No category'}
+                    </Badge>
+                    <Badge variant="outline">{primaryResourceCount}/2 primary resources</Badge>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <InlineNotice
+                title="No skill selected"
+                description="Select a skill from the table to manage its resources."
+              />
+            )}
+
+            {resourcesError ? (
+              <InlineNotice
+                title="Resources unavailable"
+                tone="error"
+                description={resourcesError}
+              />
+            ) : null}
+
+            {selectedSkill && primaryResourceCount >= 2 ? (
+              <InlineNotice
+                title="Primary limit reached"
+                description="The API rejects additional primary resources until one primary resource is unmarked or deleted."
+              />
+            ) : null}
+
+            <div className="flex flex-col gap-3">
+              {isLoadingResources ? (
+                <ResourcePlaceholder />
+              ) : resources.length > 0 ? (
+                resources.map((resource) => (
+                  <ResourceCard
+                    key={resource.id}
+                    resource={resource}
+                    onDelete={() => setResourceToDelete(resource)}
+                    onEdit={() => setResourceDrawer({ mode: 'edit', resource })}
+                  />
+                ))
+              ) : selectedSkill ? (
+                <InlineNotice
+                  title="No resources yet"
+                  description="Add a resource to this skill before it appears in roadmap node details."
+                />
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <SkillFormDrawer
+        drawer={skillDrawer}
+        onOpenChange={(open) => {
+          if (!open) setSkillDrawer(null);
+        }}
+        onSubmit={handleSubmitSkill}
+      />
+
+      <ResourceFormDrawer
+        drawer={resourceDrawer}
+        selectedSkill={selectedSkill}
+        onOpenChange={(open) => {
+          if (!open) setResourceDrawer(null);
+        }}
+        onSubmit={handleSubmitResource}
+      />
+
+      <ConfirmDeleteDialog
+        title="Delete skill"
+        confirmLabel="Delete skill"
+        description={
+          skillToDelete
+            ? `Delete "${skillToDelete.name}"? The API will block deletion if roadmap or template nodes reference this skill.`
+            : ''
+        }
+        isDeleting={isDeletingSkill}
+        onConfirm={handleDeleteSkill}
+        open={!!skillToDelete}
+        onOpenChange={(open) => {
+          if (!open) setSkillToDelete(null);
+        }}
+      />
+
+      <ConfirmDeleteDialog
+        title="Delete resource"
+        confirmLabel="Delete resource"
+        description={
+          resourceToDelete ? `Delete "${resourceToDelete.title}" from the selected skill?` : ''
+        }
+        isDeleting={isDeletingResource}
+        onConfirm={handleDeleteResource}
+        open={!!resourceToDelete}
+        onOpenChange={(open) => {
+          if (!open) setResourceToDelete(null);
+        }}
+      />
+    </div>
+  );
+}
+
+function SkillFormDrawer({
+  drawer,
+  onOpenChange,
+  onSubmit,
+}: {
+  drawer: SkillDrawerState | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: AdminSkillPayload, skill?: AdminSkill) => Promise<void>;
+}) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const skill = drawer?.skill;
+  const form = useForm<AdminSkillFormValues>({
+    defaultValues: getSkillFormDefaults(skill),
+    resolver: zodResolver(adminSkillFormSchema),
+  });
+  const errors = form.formState.errors;
+  const isOpen = !!drawer;
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset(getSkillFormDefaults(skill));
+    }
+  }, [form, isOpen, skill]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setIsSubmitting(true);
+
+    try {
+      await onSubmit(toSkillPayload(values), skill);
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(skill ? 'Skill update failed' : 'Skill creation failed', {
+        description: getApiErrorMessage(error, 'Please check the skill details and try again.'),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  return (
+    <Drawer direction="right" open={isOpen} onOpenChange={onOpenChange}>
+      <DrawerContent className="sm:max-w-xl">
+        <form className="flex min-h-0 flex-1 flex-col" noValidate onSubmit={handleSubmit}>
+          <DrawerHeader>
+            <DrawerTitle>{skill ? 'Edit skill' : 'Create skill'}</DrawerTitle>
+            <DrawerDescription>
+              Skill records drive roadmap node metadata and resource ownership.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="scrollbar-thin flex-1 overflow-y-auto px-4">
+            <FieldGroup>
+              <Field data-invalid={!!errors.name}>
+                <FieldLabel htmlFor="skill-name">Name</FieldLabel>
+                <Input id="skill-name" aria-invalid={!!errors.name} {...form.register('name')} />
+                <FieldError errors={[errors.name]} />
+              </Field>
+
+              <Field data-invalid={!!errors.roleCategory}>
+                <FieldLabel htmlFor="skill-role-category">Role category</FieldLabel>
+                <NativeSelect
+                  id="skill-role-category"
+                  aria-invalid={!!errors.roleCategory}
+                  {...form.register('roleCategory')}
+                >
+                  {ROLE_CATEGORY_VALUES.map((category) => (
+                    <option key={category} value={category}>
+                      {formatEnumLabel(category)}
+                    </option>
+                  ))}
+                </NativeSelect>
+                <FieldError errors={[errors.roleCategory]} />
+              </Field>
+
+              <Field data-invalid={!!errors.defaultEstimatedHours}>
+                <FieldLabel htmlFor="skill-hours">Default estimated hours</FieldLabel>
+                <Input
+                  id="skill-hours"
+                  placeholder="Optional"
+                  inputMode="decimal"
+                  aria-invalid={!!errors.defaultEstimatedHours}
+                  {...form.register('defaultEstimatedHours')}
+                />
+                <FieldError errors={[errors.defaultEstimatedHours]} />
+              </Field>
+
+              <Field data-invalid={!!errors.description}>
+                <FieldLabel htmlFor="skill-description">Description</FieldLabel>
+                <TextareaControl
+                  id="skill-description"
+                  placeholder="What should learners know about this skill?"
+                  aria-invalid={!!errors.description}
+                  rows={6}
+                  {...form.register('description')}
+                />
+                <FieldError errors={[errors.description]} />
+              </Field>
+            </FieldGroup>
+          </div>
+          <DrawerFooter>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Saving...' : 'Save skill'}
+            </Button>
+            <DrawerClose asChild>
+              <Button variant="outline" type="button">
+                Cancel
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </form>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function ResourceFormDrawer({
+  drawer,
+  onOpenChange,
+  onSubmit,
+  selectedSkill,
+}: {
+  drawer: ResourceDrawerState | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: AdminSkillResourcePayload, resource?: AdminSkillResource) => Promise<void>;
+  selectedSkill: AdminSkill | null;
+}) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const resource = drawer?.resource;
+  const form = useForm<AdminResourceFormValues>({
+    defaultValues: getResourceFormDefaults(resource),
+    resolver: zodResolver(adminResourceFormSchema),
+  });
+  const errors = form.formState.errors;
+  const isOpen = !!drawer;
+  const isFree = form.watch('isFree');
+  const isPrimary = form.watch('isPrimary');
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset(getResourceFormDefaults(resource));
+    }
+  }, [form, isOpen, resource]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setIsSubmitting(true);
+
+    try {
+      await onSubmit(
+        {
+          isFree: values.isFree,
+          isPrimary: values.isPrimary,
+          resourceType: values.resourceType,
+          title: values.title.trim(),
+          url: values.url.trim(),
+        },
+        resource,
+      );
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(resource ? 'Resource update failed' : 'Resource creation failed', {
+        description: getApiErrorMessage(error, 'Please check the resource details and try again.'),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  return (
+    <Drawer direction="right" open={isOpen} onOpenChange={onOpenChange}>
+      <DrawerContent className="sm:max-w-xl">
+        <form className="flex min-h-0 flex-1 flex-col" noValidate onSubmit={handleSubmit}>
+          <DrawerHeader>
+            <DrawerTitle>{resource ? 'Edit resource' : 'Create resource'}</DrawerTitle>
+            <DrawerDescription>
+              {selectedSkill
+                ? `Resources will stay scoped to ${selectedSkill.name}.`
+                : 'Select a skill before creating resources.'}
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="scrollbar-thin flex-1 overflow-y-auto px-4">
+            <FieldGroup>
+              <Field data-invalid={!!errors.title}>
+                <FieldLabel htmlFor="resource-title">Title</FieldLabel>
+                <Input
+                  id="resource-title"
+                  aria-invalid={!!errors.title}
+                  {...form.register('title')}
+                />
+                <FieldError errors={[errors.title]} />
+              </Field>
+
+              <Field data-invalid={!!errors.url}>
+                <FieldLabel htmlFor="resource-url">URL</FieldLabel>
+                <Input
+                  id="resource-url"
+                  placeholder="https://example.com/resource"
+                  aria-invalid={!!errors.url}
+                  {...form.register('url')}
+                />
+                <FieldError errors={[errors.url]} />
+              </Field>
+
+              <Field data-invalid={!!errors.resourceType}>
+                <FieldLabel htmlFor="resource-type">Resource type</FieldLabel>
+                <NativeSelect
+                  id="resource-type"
+                  aria-invalid={!!errors.resourceType}
+                  {...form.register('resourceType')}
+                >
+                  {RESOURCE_TYPE_VALUES.map((type) => (
+                    <option key={type} value={type}>
+                      {formatEnumLabel(type)}
+                    </option>
+                  ))}
+                </NativeSelect>
+                <FieldError errors={[errors.resourceType]} />
+              </Field>
+
+              <Field orientation="horizontal">
+                <Checkbox
+                  id="resource-free"
+                  checked={isFree}
+                  onCheckedChange={(checked) =>
+                    form.setValue('isFree', checked === true, { shouldValidate: true })
+                  }
+                />
+                <FieldLabel className="font-normal" htmlFor="resource-free">
+                  Free resource
+                </FieldLabel>
+              </Field>
+
+              <Field orientation="horizontal">
+                <Checkbox
+                  id="resource-primary"
+                  checked={isPrimary}
+                  onCheckedChange={(checked) =>
+                    form.setValue('isPrimary', checked === true, { shouldValidate: true })
+                  }
+                />
+                <FieldLabel className="font-normal" htmlFor="resource-primary">
+                  Primary resource
+                </FieldLabel>
+              </Field>
+            </FieldGroup>
+          </div>
+          <DrawerFooter>
+            <Button type="submit" disabled={isSubmitting || !selectedSkill}>
+              {isSubmitting ? 'Saving...' : 'Save resource'}
+            </Button>
+            <DrawerClose asChild>
+              <Button variant="outline" type="button">
+                Cancel
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </form>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function ConfirmDeleteDialog({
+  confirmLabel,
+  description,
+  isDeleting,
+  onConfirm,
+  onOpenChange,
+  open,
+  title,
+}: {
+  confirmLabel: string;
+  description: string;
+  isDeleting: boolean;
+  onConfirm: () => Promise<void>;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  title: string;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            type="button"
+            disabled={isDeleting}
+            onClick={() => {
+              void onConfirm();
+            }}
+          >
+            {isDeleting ? 'Deleting...' : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function ResourceCard({
+  onDelete,
+  onEdit,
+  resource,
+}: {
+  onDelete: () => void;
+  onEdit: () => void;
+  resource: AdminSkillResource;
+}) {
+  return (
+    <article className="border-border/80 bg-background/75 rounded-2xl border p-4">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h3 className="font-medium">{resource.title}</h3>
+            <a
+              className="text-muted-foreground hover:text-primary mt-1 block truncate text-sm"
+              href={resource.url}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {resource.url}
+            </a>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <Button size="sm" variant="outline" onClick={onEdit}>
+              Edit
+            </Button>
+            <Button size="sm" variant="destructive" onClick={onDelete}>
+              Delete
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="secondary">{formatEnumLabel(resource.resourceType)}</Badge>
+          {resource.isPrimary ? <Badge variant="outline">Primary</Badge> : null}
+          {resource.isFree ? (
+            <Badge variant="outline">Free</Badge>
+          ) : (
+            <Badge variant="outline">Paid</Badge>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function InlineNotice({
+  description,
+  title,
+  tone = 'default',
+}: {
+  description: string;
+  title: string;
+  tone?: 'default' | 'error';
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border p-4',
+        tone === 'error' ? 'border-destructive/30 bg-destructive/5' : 'border-border bg-muted/30',
+      )}
+    >
+      <p className="font-medium">{title}</p>
+      <p className="text-muted-foreground mt-1 text-sm">{description}</p>
+    </div>
+  );
+}
+
+function TablePlaceholder({ rows }: { rows: number }) {
+  return Array.from({ length: rows }).map((_, index) => (
+    <TableRow key={index}>
+      <TableCell className="h-16" colSpan={5}>
+        <Skeleton className="h-4 w-full max-w-180 rounded-full" />
+      </TableCell>
+    </TableRow>
+  ));
+}
+
+function ResourcePlaceholder() {
+  return Array.from({ length: 3 }).map((_, index) => (
+    <div key={index} className="border-border rounded-2xl border p-4">
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-4 w-3/4 rounded-full" />
+        <Skeleton className="h-4 w-1/2 rounded-full" />
+        <Separator />
+        <div className="flex gap-2">
+          <Skeleton className="h-6 w-20 rounded-full" />
+          <Skeleton className="h-6 w-16 rounded-full" />
+        </div>
+      </div>
+    </div>
+  ));
+}
+
+function NativeSelect({ className, ...props }: ComponentProps<'select'>) {
+  return <select className={cn(CONTROL_CLASS_NAME, className)} {...props} />;
+}
+
+function TextareaControl({ className, ...props }: ComponentProps<'textarea'>) {
+  return <textarea className={cn(CONTROL_CLASS_NAME, 'min-h-28 resize-y', className)} {...props} />;
+}
+
+function getSkillFormDefaults(skill?: AdminSkill): AdminSkillFormValues {
+  return {
+    defaultEstimatedHours:
+      skill?.defaultEstimatedHours === null || skill?.defaultEstimatedHours === undefined
+        ? ''
+        : String(skill.defaultEstimatedHours),
+    description: skill?.description ?? '',
+    name: skill?.name ?? '',
+    roleCategory: skill?.roleCategory ?? 'WEB_DEVELOPMENT',
+  };
+}
+
+function getResourceFormDefaults(resource?: AdminSkillResource): AdminResourceFormValues {
+  return {
+    isFree: resource?.isFree ?? true,
+    isPrimary: resource?.isPrimary ?? false,
+    resourceType: resource?.resourceType ?? 'DOCS',
+    title: resource?.title ?? '',
+    url: resource?.url ?? '',
+  };
+}
+
+function toSkillPayload(values: AdminSkillFormValues): AdminSkillPayload {
+  const description = values.description.trim();
+  const defaultEstimatedHours = values.defaultEstimatedHours.trim();
+
+  return {
+    defaultEstimatedHours: defaultEstimatedHours ? Number(defaultEstimatedHours) : null,
+    description: description || null,
+    name: values.name.trim(),
+    roleCategory: values.roleCategory,
+  };
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+
+  return Number.isNaN(date.getTime()) ? 'Unknown' : DATE_FORMATTER.format(date);
+}
+
+function formatEnumLabel(value: ResourceType | RoleCategory): string {
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function formatHours(value: null | number): string {
+  if (value === null) {
+    return 'Not set';
+  }
+
+  return `${value}h`;
+}

--- a/apps/web/app/(admin)/admin/skills/_components/admin-skills-content.tsx
+++ b/apps/web/app/(admin)/admin/skills/_components/admin-skills-content.tsx
@@ -316,7 +316,7 @@ export function AdminSkillsContent() {
         </div>
       </section>
 
-      <div className="grid min-w-0 gap-4 2xl:grid-cols-[minmax(0,1.25fr)_minmax(420px,0.75fr)]">
+      <div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">
         <Card className="bg-card/90 backdrop-blur-md">
           <CardHeader>
             <CardTitle>Skill catalog</CardTitle>
@@ -464,7 +464,7 @@ export function AdminSkillsContent() {
           </CardContent>
         </Card>
 
-        <Card className="bg-card/90 backdrop-blur-md">
+        <Card className="bg-card/90 backdrop-blur-md lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:overflow-y-auto">
           <CardHeader>
             <CardTitle>Selected-skill resources</CardTitle>
             <CardDescription>

--- a/apps/web/app/(admin)/admin/skills/_components/admin-skills-content.tsx
+++ b/apps/web/app/(admin)/admin/skills/_components/admin-skills-content.tsx
@@ -296,9 +296,6 @@ export function AdminSkillsContent() {
       <section className="border-border/70 bg-card/90 rounded-3xl border p-5 shadow-sm backdrop-blur-md">
         <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
           <div className="flex max-w-3xl flex-col gap-2">
-            <Badge variant="outline" className="w-fit">
-              Phase 1
-            </Badge>
             <div className="flex flex-col gap-1">
               <h1 className="font-heading text-foreground text-3xl leading-tight sm:text-4xl">
                 Skills and resources

--- a/apps/web/app/(admin)/admin/skills/page.tsx
+++ b/apps/web/app/(admin)/admin/skills/page.tsx
@@ -1,0 +1,5 @@
+import { AdminSkillsContent } from './_components/admin-skills-content';
+
+export default function AdminSkillsPage() {
+  return <AdminSkillsContent />;
+}

--- a/apps/web/app/(admin)/admin/templates/[templateId]/page.tsx
+++ b/apps/web/app/(admin)/admin/templates/[templateId]/page.tsx
@@ -1,0 +1,9 @@
+import { AdminTemplateNodesPageContent } from '../_components/admin-template-nodes-page-content';
+
+export default async function AdminTemplateNodesPage(
+  props: PageProps<'/admin/templates/[templateId]'>,
+) {
+  const { templateId } = await props.params;
+
+  return <AdminTemplateNodesPageContent templateId={templateId} />;
+}

--- a/apps/web/app/(admin)/admin/templates/_components/admin-template-nodes-page-content.tsx
+++ b/apps/web/app/(admin)/admin/templates/_components/admin-template-nodes-page-content.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import type { Route } from 'next';
+
+import { ArrowLeftIcon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Badge } from '@repo/design-system/components/ui/badge';
+import { Button } from '@repo/design-system/components/ui/button';
+import { Skeleton } from '@repo/design-system/components/ui/skeleton';
+import { cn } from '@repo/design-system/lib/utils';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import type { AdminTemplate, RoleCategory } from '@/types/admin-content';
+
+import { adminContentService, getApiErrorMessage } from '@/services/admin-content.service';
+
+import { AdminTemplateNodesPanel } from './admin-template-nodes-panel';
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
+
+export function AdminTemplateNodesPageContent({ templateId }: { templateId: string }) {
+  const [template, setTemplate] = useState<AdminTemplate | null>(null);
+  const [isLoadingTemplate, setIsLoadingTemplate] = useState(true);
+  const [templateError, setTemplateError] = useState<string | null>(null);
+  const [templateRefreshKey, setTemplateRefreshKey] = useState(0);
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    setIsLoadingTemplate(true);
+    setTemplateError(null);
+
+    void adminContentService
+      .getTemplate(templateId)
+      .then((response) => {
+        if (!isCurrent) return;
+        setTemplate(response);
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) return;
+        setTemplate(null);
+        setTemplateError(getApiErrorMessage(error, 'Unable to load this template.'));
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingTemplate(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [templateId, templateRefreshKey]);
+
+  const refreshTemplate = () => {
+    setTemplateRefreshKey((current) => current + 1);
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <section className="border-border/70 bg-card/90 rounded-3xl border p-5 shadow-sm backdrop-blur-md">
+        <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+          <div className="flex max-w-3xl flex-col gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-fit px-0 hover:bg-transparent"
+              render={
+                <Link href={'/admin/templates' as Route<string>}>
+                  <HugeiconsIcon data-icon="inline-start" icon={ArrowLeftIcon} />
+                  Templates
+                </Link>
+              }
+            />
+            <div className="flex flex-col gap-1">
+              <h1 className="font-heading text-foreground text-3xl leading-tight sm:text-4xl">
+                Template node editor
+              </h1>
+              <p className="text-muted-foreground text-sm sm:text-base">
+                Edit grouped sections and lessons for the selected roadmap template.
+              </p>
+            </div>
+            {template ? (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="secondary">{template.title}</Badge>
+                <Badge variant="outline">{formatEnumLabel(template.roleCategory)}</Badge>
+                <Badge variant="outline">Updated {formatDate(template.updatedAt)}</Badge>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              disabled={isLoadingTemplate}
+              onClick={() => refreshTemplate()}
+            >
+              Refresh metadata
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {isLoadingTemplate ? (
+        <TemplateMetadataPlaceholder />
+      ) : templateError ? (
+        <InlineNotice title="Template unavailable" tone="error" description={templateError} />
+      ) : (
+        <AdminTemplateNodesPanel selectedTemplate={template} />
+      )}
+    </div>
+  );
+}
+
+function TemplateMetadataPlaceholder() {
+  return (
+    <div className="border-border/70 bg-card/90 rounded-3xl border p-5 shadow-sm backdrop-blur-md">
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-5 w-48 rounded-full" />
+        <Skeleton className="h-20 w-full rounded-2xl" />
+        <Skeleton className="h-56 w-full rounded-2xl" />
+      </div>
+    </div>
+  );
+}
+
+function InlineNotice({
+  description,
+  title,
+  tone = 'default',
+}: {
+  description: string;
+  title: string;
+  tone?: 'default' | 'error';
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border p-4',
+        tone === 'error' ? 'border-destructive/30 bg-destructive/5' : 'border-border bg-muted/30',
+      )}
+    >
+      <p className="font-medium">{title}</p>
+      <p className="text-muted-foreground mt-1 text-sm">{description}</p>
+    </div>
+  );
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+
+  return Number.isNaN(date.getTime()) ? 'Unknown' : DATE_FORMATTER.format(date);
+}
+
+function formatEnumLabel(value: RoleCategory): string {
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+}

--- a/apps/web/app/(admin)/admin/templates/_components/admin-template-nodes-panel.tsx
+++ b/apps/web/app/(admin)/admin/templates/_components/admin-template-nodes-panel.tsx
@@ -1,0 +1,913 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@repo/design-system/components/ui/alert-dialog';
+import { Badge } from '@repo/design-system/components/ui/badge';
+import { Button } from '@repo/design-system/components/ui/button';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@repo/design-system/components/ui/card';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@repo/design-system/components/ui/drawer';
+import { Field, FieldError, FieldGroup, FieldLabel } from '@repo/design-system/components/ui/field';
+import { Input } from '@repo/design-system/components/ui/input';
+import { Separator } from '@repo/design-system/components/ui/separator';
+import { Skeleton } from '@repo/design-system/components/ui/skeleton';
+import { toast } from '@repo/design-system/lib/toast';
+import { cn } from '@repo/design-system/lib/utils';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import type {
+  AdminSkill,
+  AdminTemplate,
+  AdminTemplateNode,
+  AdminTemplateNodePayload,
+  TemplateNodeType,
+} from '@/types/admin-content';
+
+import { adminContentService, getApiErrorMessage } from '@/services/admin-content.service';
+import {
+  adminTemplateNodeFormSchema,
+  TEMPLATE_NODE_TYPE_VALUES,
+  type AdminTemplateNodeFormValues,
+} from '@/validations/admin-content.schema';
+
+const EMPTY_NODES: AdminTemplateNode[] = [];
+const EMPTY_SKILLS: AdminSkill[] = [];
+const SKILL_OPTIONS_LIMIT = 100;
+const CONTROL_CLASS_NAME =
+  'border-border focus-visible:border-border bg-background text-foreground disabled:border-disabled disabled:bg-background disabled:text-disabled disabled:placeholder:text-disabled placeholder:text-muted-foreground/70 focus-visible:ring-ring min-h-10 w-full min-w-0 rounded-md border px-3 py-2.5 text-base shadow-[0_1px_2px_0_rgba(139,92,246,0.10)] transition-all outline-none focus-visible:shadow-none focus-visible:ring-2 disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20';
+
+type NodeDrawerState =
+  | {
+      defaults?: Partial<AdminTemplateNodeFormValues>;
+      mode: 'create';
+      node?: undefined;
+    }
+  | {
+      defaults?: undefined;
+      mode: 'edit';
+      node: AdminTemplateNode;
+    };
+
+interface TemplateNodeSection {
+  children: AdminTemplateNode[];
+  node: AdminTemplateNode;
+}
+
+interface AdminTemplateNodesPanelProps {
+  selectedTemplate: AdminTemplate | null;
+}
+
+export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodesPanelProps) {
+  const [nodes, setNodes] = useState<AdminTemplateNode[]>(EMPTY_NODES);
+  const [skills, setSkills] = useState<AdminSkill[]>(EMPTY_SKILLS);
+  const [isLoadingNodes, setIsLoadingNodes] = useState(false);
+  const [isLoadingSkills, setIsLoadingSkills] = useState(false);
+  const [nodesError, setNodesError] = useState<string | null>(null);
+  const [skillsError, setSkillsError] = useState<string | null>(null);
+  const [nodesRefreshKey, setNodesRefreshKey] = useState(0);
+  const [nodeDrawer, setNodeDrawer] = useState<NodeDrawerState | null>(null);
+  const [nodeToDelete, setNodeToDelete] = useState<AdminTemplateNode | null>(null);
+  const [isDeletingNode, setIsDeletingNode] = useState(false);
+
+  const sections = useMemo(() => buildNodeSections(nodes), [nodes]);
+  const orphanNodes = useMemo(() => getOrphanNodes(nodes), [nodes]);
+  const leafNodeCount = nodes.filter((node) => isLeafNodeType(node.nodeType)).length;
+
+  useEffect(() => {
+    if (!selectedTemplate) {
+      setNodes(EMPTY_NODES);
+      setNodesError(null);
+      return;
+    }
+
+    let isCurrent = true;
+
+    setIsLoadingNodes(true);
+    setNodesError(null);
+
+    void adminContentService
+      .listTemplateNodes(selectedTemplate.id)
+      .then((response) => {
+        if (!isCurrent) return;
+        setNodes(response.nodes);
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) return;
+        setNodes(EMPTY_NODES);
+        setNodesError(getApiErrorMessage(error, 'Unable to load template nodes.'));
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingNodes(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [nodesRefreshKey, selectedTemplate]);
+
+  useEffect(() => {
+    if (!selectedTemplate) {
+      setSkills(EMPTY_SKILLS);
+      setSkillsError(null);
+      return;
+    }
+
+    let isCurrent = true;
+
+    setIsLoadingSkills(true);
+    setSkillsError(null);
+
+    void adminContentService
+      .listSkills({
+        page: 1,
+        perPage: SKILL_OPTIONS_LIMIT,
+        roleCategory: selectedTemplate.roleCategory,
+      })
+      .then((response) => {
+        if (!isCurrent) return;
+        setSkills(response.data);
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) return;
+        setSkills(EMPTY_SKILLS);
+        setSkillsError(getApiErrorMessage(error, 'Unable to load skills for this template.'));
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingSkills(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [selectedTemplate]);
+
+  const refreshNodes = () => {
+    setNodesRefreshKey((current) => current + 1);
+  };
+
+  const handleSubmitNode = async (payload: AdminTemplateNodePayload, node?: AdminTemplateNode) => {
+    if (!selectedTemplate) return;
+
+    if (node) {
+      await adminContentService.updateTemplateNode(selectedTemplate.id, node.id, payload);
+      toast.success('Template node updated');
+    } else {
+      await adminContentService.createTemplateNode(selectedTemplate.id, payload);
+      toast.success('Template node created');
+    }
+
+    refreshNodes();
+  };
+
+  const handleDeleteNode = async () => {
+    if (!selectedTemplate || !nodeToDelete) return;
+
+    setIsDeletingNode(true);
+
+    try {
+      await adminContentService.deleteTemplateNode(selectedTemplate.id, nodeToDelete.id);
+      toast.success('Template node deleted');
+      setNodeToDelete(null);
+      refreshNodes();
+    } catch (error) {
+      toast.error('Template node deletion failed', {
+        description: getApiErrorMessage(error, 'Unable to delete this template node.'),
+      });
+    } finally {
+      setIsDeletingNode(false);
+    }
+  };
+
+  return (
+    <Card className="bg-card/90 backdrop-blur-md">
+      <CardHeader>
+        <CardTitle>Template nodes</CardTitle>
+        <CardDescription>
+          {selectedTemplate
+            ? `Grouped editor for ${selectedTemplate.title}.`
+            : 'Select a template to manage its grouped node list.'}
+        </CardDescription>
+        <CardAction>
+          <Button size="sm" variant="outline" disabled={!selectedTemplate} onClick={refreshNodes}>
+            Refresh
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {selectedTemplate ? (
+          <div className="bg-muted/30 rounded-2xl border p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <p className="text-muted-foreground text-xs tracking-[0.2em] uppercase">
+                  Selected template
+                </p>
+                <h2 className="font-heading mt-2 text-xl">{selectedTemplate.title}</h2>
+              </div>
+              <Badge variant="secondary">{formatEnumLabel(selectedTemplate.roleCategory)}</Badge>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Badge variant="outline">{sections.length} sections</Badge>
+              <Badge variant="outline">{leafNodeCount} lessons</Badge>
+            </div>
+          </div>
+        ) : (
+          <InlineNotice
+            title="No template selected"
+            description="Select a template from the catalog to edit its nodes."
+          />
+        )}
+
+        {nodesError ? (
+          <InlineNotice title="Nodes unavailable" tone="error" description={nodesError} />
+        ) : null}
+
+        {skillsError ? (
+          <InlineNotice title="Skills unavailable" tone="error" description={skillsError} />
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            disabled={!selectedTemplate}
+            onClick={() => setNodeDrawer({ defaults: { nodeType: 'GROUP' }, mode: 'create' })}
+          >
+            Add group
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!selectedTemplate}
+            onClick={() => setNodeDrawer({ defaults: { nodeType: 'MILESTONE' }, mode: 'create' })}
+          >
+            Add milestone
+          </Button>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          {isLoadingNodes ? (
+            <NodeListPlaceholder />
+          ) : sections.length > 0 ? (
+            sections.map((section) => (
+              <NodeSectionCard
+                key={section.node.id}
+                section={section}
+                skills={skills}
+                onAddChild={() =>
+                  setNodeDrawer({
+                    defaults: {
+                      nodeType: 'REQUIRED',
+                      parentId: section.node.id,
+                    },
+                    mode: 'create',
+                  })
+                }
+                onDeleteNode={setNodeToDelete}
+                onEditNode={(node) => setNodeDrawer({ mode: 'edit', node })}
+              />
+            ))
+          ) : selectedTemplate ? (
+            <InlineNotice
+              title="No nodes yet"
+              description="Create a group or milestone section, then add required or optional skills under it."
+            />
+          ) : null}
+
+          {orphanNodes.length > 0 ? (
+            <OrphanNodesList
+              nodes={orphanNodes}
+              skills={skills}
+              onDeleteNode={setNodeToDelete}
+              onEditNode={(node) => setNodeDrawer({ mode: 'edit', node })}
+            />
+          ) : null}
+        </div>
+      </CardContent>
+
+      <TemplateNodeFormDrawer
+        drawer={nodeDrawer}
+        isLoadingSkills={isLoadingSkills}
+        nodes={nodes}
+        skills={skills}
+        template={selectedTemplate}
+        onOpenChange={(open) => {
+          if (!open) setNodeDrawer(null);
+        }}
+        onSubmit={handleSubmitNode}
+      />
+
+      <ConfirmDeleteDialog
+        title="Delete template node"
+        confirmLabel="Delete node"
+        description={getDeleteDescription(nodeToDelete)}
+        isDeleting={isDeletingNode}
+        onConfirm={handleDeleteNode}
+        open={!!nodeToDelete}
+        onOpenChange={(open) => {
+          if (!open) setNodeToDelete(null);
+        }}
+      />
+    </Card>
+  );
+}
+
+function NodeSectionCard({
+  onAddChild,
+  onDeleteNode,
+  onEditNode,
+  section,
+  skills,
+}: {
+  onAddChild: () => void;
+  onDeleteNode: (node: AdminTemplateNode) => void;
+  onEditNode: (node: AdminTemplateNode) => void;
+  section: TemplateNodeSection;
+  skills: AdminSkill[];
+}) {
+  const isMilestone = section.node.nodeType === 'MILESTONE';
+
+  return (
+    <section
+      className={cn(
+        'rounded-lg border',
+        isMilestone ? 'border-primary/30 bg-primary/5' : 'border-border bg-background/75',
+      )}
+    >
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-sm font-semibold">{section.node.name}</h3>
+              <Badge variant={isMilestone ? 'default' : 'secondary'}>
+                {formatEnumLabel(section.node.nodeType)}
+              </Badge>
+              <Badge variant="outline">{section.children.length} lessons</Badge>
+            </div>
+            {section.node.description ? (
+              <p className="text-muted-foreground mt-2 text-sm">{section.node.description}</p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-2">
+            <Button size="sm" variant="outline" onClick={onAddChild}>
+              Add lesson
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => onEditNode(section.node)}>
+              Edit
+            </Button>
+            <Button size="sm" variant="destructive" onClick={() => onDeleteNode(section.node)}>
+              Delete
+            </Button>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="flex flex-col gap-2">
+          {section.children.length > 0 ? (
+            section.children.map((node) => (
+              <LeafNodeRow
+                key={node.id}
+                node={node}
+                skills={skills}
+                onDelete={() => onDeleteNode(node)}
+                onEdit={() => onEditNode(node)}
+              />
+            ))
+          ) : (
+            <p className="text-muted-foreground px-1 py-3 text-sm">
+              No required or optional skills in this section.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LeafNodeRow({
+  node,
+  onDelete,
+  onEdit,
+  skills,
+}: {
+  node: AdminTemplateNode;
+  onDelete: () => void;
+  onEdit: () => void;
+  skills: AdminSkill[];
+}) {
+  const skillName = skills.find((skill) => skill.id === node.skillId)?.name;
+
+  return (
+    <article className="border-border bg-card/80 rounded-md border p-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="text-sm font-medium">{node.name}</h4>
+            <Badge variant={node.nodeType === 'REQUIRED' ? 'default' : 'outline'}>
+              {formatEnumLabel(node.nodeType)}
+            </Badge>
+          </div>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {skillName ?? node.skillId ?? 'No skill linked'}
+            {node.estimatedHours === null ? '' : ` - ${node.estimatedHours}h`}
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Button size="sm" variant="outline" onClick={onEdit}>
+            Edit
+          </Button>
+          <Button size="sm" variant="destructive" onClick={onDelete}>
+            Delete
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function OrphanNodesList({
+  nodes,
+  onDeleteNode,
+  onEditNode,
+  skills,
+}: {
+  nodes: AdminTemplateNode[];
+  onDeleteNode: (node: AdminTemplateNode) => void;
+  onEditNode: (node: AdminTemplateNode) => void;
+  skills: AdminSkill[];
+}) {
+  return (
+    <section className="border-destructive/30 bg-destructive/5 rounded-lg border p-4">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-sm font-semibold">Unsectioned lessons</h3>
+        <p className="text-muted-foreground text-sm">
+          These required or optional nodes do not have a visible parent section.
+        </p>
+      </div>
+      <div className="mt-3 flex flex-col gap-2">
+        {nodes.map((node) => (
+          <LeafNodeRow
+            key={node.id}
+            node={node}
+            skills={skills}
+            onDelete={() => onDeleteNode(node)}
+            onEdit={() => onEditNode(node)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function TemplateNodeFormDrawer({
+  drawer,
+  isLoadingSkills,
+  nodes,
+  onOpenChange,
+  onSubmit,
+  skills,
+  template,
+}: {
+  drawer: NodeDrawerState | null;
+  isLoadingSkills: boolean;
+  nodes: AdminTemplateNode[];
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: AdminTemplateNodePayload, node?: AdminTemplateNode) => Promise<void>;
+  skills: AdminSkill[];
+  template: AdminTemplate | null;
+}) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const node = drawer?.node;
+  const form = useForm<AdminTemplateNodeFormValues>({
+    defaultValues: getNodeFormDefaults(drawer),
+    resolver: zodResolver(adminTemplateNodeFormSchema),
+  });
+  const errors = form.formState.errors;
+  const isOpen = !!drawer;
+  const nodeType = form.watch('nodeType');
+  const isLeafNode = isLeafNodeType(nodeType);
+  const parentSections = useMemo(
+    () =>
+      nodes
+        .filter((candidate) => isSectionNodeType(candidate.nodeType) && candidate.id !== node?.id)
+        .sort(sortTemplateNodes),
+    [node?.id, nodes],
+  );
+  const skillOptions = useMemo(() => getSkillOptions(skills, node), [node, skills]);
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset(getNodeFormDefaults(drawer));
+    }
+  }, [drawer, form, isOpen]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setIsSubmitting(true);
+
+    try {
+      await onSubmit(toNodePayload(values), node);
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(node ? 'Template node update failed' : 'Template node creation failed', {
+        description: getApiErrorMessage(error, 'Please check the node details and try again.'),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  return (
+    <Drawer direction="right" open={isOpen} onOpenChange={onOpenChange}>
+      <DrawerContent className="sm:max-w-xl">
+        <form className="flex min-h-0 flex-1 flex-col" noValidate onSubmit={handleSubmit}>
+          <DrawerHeader>
+            <DrawerTitle>{node ? 'Edit template node' : 'Create template node'}</DrawerTitle>
+            <DrawerDescription>
+              {template
+                ? `Nodes will stay scoped to ${template.title}.`
+                : 'Select a template before editing nodes.'}
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="scrollbar-thin flex-1 overflow-y-auto px-4">
+            <FieldGroup>
+              <Field data-invalid={!!errors.nodeType}>
+                <FieldLabel htmlFor="template-node-type">Node type</FieldLabel>
+                <NativeSelect
+                  id="template-node-type"
+                  aria-invalid={!!errors.nodeType}
+                  {...form.register('nodeType')}
+                >
+                  {TEMPLATE_NODE_TYPE_VALUES.map((type) => (
+                    <option key={type} value={type}>
+                      {formatEnumLabel(type)}
+                    </option>
+                  ))}
+                </NativeSelect>
+                <FieldError errors={[errors.nodeType]} />
+              </Field>
+
+              <Field data-invalid={!!errors.name}>
+                <FieldLabel htmlFor="template-node-name">Name</FieldLabel>
+                <Input
+                  id="template-node-name"
+                  aria-invalid={!!errors.name}
+                  {...form.register('name')}
+                />
+                <FieldError errors={[errors.name]} />
+              </Field>
+
+              {nodeType === 'MILESTONE' ? (
+                <Field data-invalid={!!errors.description}>
+                  <FieldLabel htmlFor="template-node-description">Description</FieldLabel>
+                  <TextareaControl
+                    id="template-node-description"
+                    placeholder="Optional milestone brief."
+                    aria-invalid={!!errors.description}
+                    rows={5}
+                    {...form.register('description')}
+                  />
+                  <FieldError errors={[errors.description]} />
+                </Field>
+              ) : null}
+
+              {isLeafNode ? (
+                <>
+                  <Field data-invalid={!!errors.parentId}>
+                    <FieldLabel htmlFor="template-node-parent">Parent section</FieldLabel>
+                    <NativeSelect
+                      id="template-node-parent"
+                      aria-invalid={!!errors.parentId}
+                      {...form.register('parentId')}
+                    >
+                      <option value="">Choose a section</option>
+                      {parentSections.map((section) => (
+                        <option key={section.id} value={section.id}>
+                          {section.name}
+                        </option>
+                      ))}
+                    </NativeSelect>
+                    <FieldError errors={[errors.parentId]} />
+                  </Field>
+
+                  <Field data-invalid={!!errors.skillId}>
+                    <FieldLabel htmlFor="template-node-skill">Skill</FieldLabel>
+                    <NativeSelect
+                      id="template-node-skill"
+                      disabled={isLoadingSkills}
+                      aria-invalid={!!errors.skillId}
+                      {...form.register('skillId')}
+                    >
+                      <option value="">
+                        {isLoadingSkills ? 'Loading skills...' : 'Choose a skill'}
+                      </option>
+                      {skillOptions.map((skill) => (
+                        <option key={skill.id} value={skill.id}>
+                          {skill.name}
+                        </option>
+                      ))}
+                    </NativeSelect>
+                    <FieldError errors={[errors.skillId]} />
+                  </Field>
+
+                  <Field data-invalid={!!errors.estimatedHours}>
+                    <FieldLabel htmlFor="template-node-hours">Estimated hours</FieldLabel>
+                    <Input
+                      id="template-node-hours"
+                      placeholder="Optional"
+                      inputMode="decimal"
+                      aria-invalid={!!errors.estimatedHours}
+                      {...form.register('estimatedHours')}
+                    />
+                    <FieldError errors={[errors.estimatedHours]} />
+                  </Field>
+                </>
+              ) : null}
+            </FieldGroup>
+          </div>
+          <DrawerFooter>
+            <Button type="submit" disabled={isSubmitting || !template}>
+              {isSubmitting ? 'Saving...' : 'Save node'}
+            </Button>
+            <DrawerClose asChild>
+              <Button variant="outline" type="button">
+                Cancel
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </form>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function ConfirmDeleteDialog({
+  confirmLabel,
+  description,
+  isDeleting,
+  onConfirm,
+  onOpenChange,
+  open,
+  title,
+}: {
+  confirmLabel: string;
+  description: string;
+  isDeleting: boolean;
+  onConfirm: () => Promise<void>;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  title: string;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            type="button"
+            disabled={isDeleting}
+            onClick={() => {
+              void onConfirm();
+            }}
+          >
+            {isDeleting ? 'Deleting...' : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function InlineNotice({
+  description,
+  title,
+  tone = 'default',
+}: {
+  description: string;
+  title: string;
+  tone?: 'default' | 'error';
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border p-4',
+        tone === 'error' ? 'border-destructive/30 bg-destructive/5' : 'border-border bg-muted/30',
+      )}
+    >
+      <p className="font-medium">{title}</p>
+      <p className="text-muted-foreground mt-1 text-sm">{description}</p>
+    </div>
+  );
+}
+
+function NodeListPlaceholder() {
+  return Array.from({ length: 3 }).map((_, index) => (
+    <div key={index} className="border-border rounded-lg border p-4">
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-4 w-3/4 rounded-full" />
+        <Skeleton className="h-4 w-1/2 rounded-full" />
+        <Separator />
+        <Skeleton className="h-14 w-full rounded-md" />
+      </div>
+    </div>
+  ));
+}
+
+function NativeSelect({ className, ...props }: ComponentProps<'select'>) {
+  return <select className={cn(CONTROL_CLASS_NAME, className)} {...props} />;
+}
+
+function TextareaControl({ className, ...props }: ComponentProps<'textarea'>) {
+  return <textarea className={cn(CONTROL_CLASS_NAME, 'min-h-28 resize-y', className)} {...props} />;
+}
+
+function buildNodeSections(nodes: AdminTemplateNode[]): TemplateNodeSection[] {
+  const childrenByParentId = nodes.reduce<Map<string, AdminTemplateNode[]>>((childMap, node) => {
+    if (!node.parentId || !isLeafNodeType(node.nodeType)) {
+      return childMap;
+    }
+
+    const children = childMap.get(node.parentId) ?? [];
+    children.push(node);
+    childMap.set(node.parentId, children);
+
+    return childMap;
+  }, new Map());
+
+  return nodes
+    .filter((node) => !node.parentId && isSectionNodeType(node.nodeType))
+    .sort(sortTemplateNodes)
+    .map((node) => ({
+      children: (childrenByParentId.get(node.id) ?? []).sort(sortTemplateNodes),
+      node,
+    }));
+}
+
+function getOrphanNodes(nodes: AdminTemplateNode[]): AdminTemplateNode[] {
+  const sectionIds = new Set(
+    nodes.filter((node) => isSectionNodeType(node.nodeType)).map((node) => node.id),
+  );
+
+  return nodes
+    .filter(
+      (node) => isLeafNodeType(node.nodeType) && (!node.parentId || !sectionIds.has(node.parentId)),
+    )
+    .sort(sortTemplateNodes);
+}
+
+function getSkillOptions(skills: AdminSkill[], node?: AdminTemplateNode): AdminSkill[] {
+  if (!node?.skillId || skills.some((skill) => skill.id === node.skillId)) {
+    return skills;
+  }
+
+  return [
+    ...skills,
+    {
+      createdAt: node.createdAt,
+      defaultEstimatedHours: node.estimatedHours,
+      description: null,
+      id: node.skillId,
+      name: `${node.name} (current skill)`,
+      roleCategory: null,
+      updatedAt: node.createdAt,
+    },
+  ];
+}
+
+function getNodeFormDefaults(drawer: NodeDrawerState | null): AdminTemplateNodeFormValues {
+  if (drawer?.mode === 'edit') {
+    return {
+      description: drawer.node.description ?? '',
+      estimatedHours:
+        drawer.node.estimatedHours === null || drawer.node.estimatedHours === undefined
+          ? ''
+          : String(drawer.node.estimatedHours),
+      name: drawer.node.name,
+      nodeType: drawer.node.nodeType,
+      parentId: drawer.node.parentId ?? '',
+      skillId: drawer.node.skillId ?? '',
+    };
+  }
+
+  return {
+    description: drawer?.defaults?.description ?? '',
+    estimatedHours: drawer?.defaults?.estimatedHours ?? '',
+    name: drawer?.defaults?.name ?? '',
+    nodeType: drawer?.defaults?.nodeType ?? 'GROUP',
+    parentId: drawer?.defaults?.parentId ?? '',
+    skillId: drawer?.defaults?.skillId ?? '',
+  };
+}
+
+function toNodePayload(values: AdminTemplateNodeFormValues): AdminTemplateNodePayload {
+  const nodeType = values.nodeType;
+  const name = values.name.trim();
+
+  if (nodeType === 'GROUP') {
+    return {
+      description: null,
+      estimatedHours: null,
+      name,
+      nodeType,
+      parentId: null,
+      skillId: null,
+    };
+  }
+
+  if (nodeType === 'MILESTONE') {
+    const description = values.description.trim();
+
+    return {
+      description: description || null,
+      estimatedHours: null,
+      name,
+      nodeType,
+      parentId: null,
+      skillId: null,
+    };
+  }
+
+  const estimatedHours = values.estimatedHours.trim();
+
+  return {
+    description: null,
+    estimatedHours: estimatedHours ? Number(estimatedHours) : null,
+    name,
+    nodeType,
+    parentId: values.parentId,
+    skillId: values.skillId,
+  };
+}
+
+function getDeleteDescription(node: AdminTemplateNode | null): string {
+  if (!node) {
+    return '';
+  }
+
+  if (isSectionNodeType(node.nodeType)) {
+    return `Delete "${node.name}"? Required and optional lessons under this section will also be removed.`;
+  }
+
+  return `Delete "${node.name}" from this template?`;
+}
+
+function sortTemplateNodes(left: AdminTemplateNode, right: AdminTemplateNode): number {
+  if (left.posY !== right.posY) {
+    return left.posY - right.posY;
+  }
+
+  if (left.posX !== right.posX) {
+    return left.posX - right.posX;
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
+function isSectionNodeType(nodeType: TemplateNodeType): boolean {
+  return nodeType === 'GROUP' || nodeType === 'MILESTONE';
+}
+
+function isLeafNodeType(nodeType: TemplateNodeType): boolean {
+  return nodeType === 'REQUIRED' || nodeType === 'OPTIONAL';
+}
+
+function formatEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+}

--- a/apps/web/app/(admin)/admin/templates/_components/admin-template-nodes-panel.tsx
+++ b/apps/web/app/(admin)/admin/templates/_components/admin-template-nodes-panel.tsx
@@ -3,6 +3,8 @@
 import type { ComponentProps } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowDown01Icon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon } from '@hugeicons/react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -94,6 +96,7 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
   const [nodeDrawer, setNodeDrawer] = useState<NodeDrawerState | null>(null);
   const [nodeToDelete, setNodeToDelete] = useState<AdminTemplateNode | null>(null);
   const [isDeletingNode, setIsDeletingNode] = useState(false);
+  const [openSectionIds, setOpenSectionIds] = useState<Set<string>>(new Set());
 
   const sections = useMemo(() => buildNodeSections(nodes), [nodes]);
   const orphanNodes = useMemo(() => getOrphanNodes(nodes), [nodes]);
@@ -132,6 +135,10 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
       isCurrent = false;
     };
   }, [nodesRefreshKey, selectedTemplate]);
+
+  useEffect(() => {
+    setOpenSectionIds(new Set());
+  }, [selectedTemplate?.id]);
 
   useEffect(() => {
     if (!selectedTemplate) {
@@ -175,6 +182,20 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
     setNodesRefreshKey((current) => current + 1);
   };
 
+  const toggleSection = (sectionId: string) => {
+    setOpenSectionIds((currentSectionIds) => {
+      const nextSectionIds = new Set(currentSectionIds);
+
+      if (nextSectionIds.has(sectionId)) {
+        nextSectionIds.delete(sectionId);
+      } else {
+        nextSectionIds.add(sectionId);
+      }
+
+      return nextSectionIds;
+    });
+  };
+
   const handleSubmitNode = async (payload: AdminTemplateNodePayload, node?: AdminTemplateNode) => {
     if (!selectedTemplate) return;
 
@@ -182,7 +203,20 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
       await adminContentService.updateTemplateNode(selectedTemplate.id, node.id, payload);
       toast.success('Template node updated');
     } else {
-      await adminContentService.createTemplateNode(selectedTemplate.id, payload);
+      const createdNode = await adminContentService.createTemplateNode(
+        selectedTemplate.id,
+        payload,
+      );
+
+      if (createdNode.nodeType === 'GROUP' || createdNode.parentId) {
+        setOpenSectionIds((currentSectionIds) => {
+          const nextSectionIds = new Set(currentSectionIds);
+          nextSectionIds.add(createdNode.parentId ?? createdNode.id);
+
+          return nextSectionIds;
+        });
+      }
+
       toast.success('Template node created');
     }
 
@@ -211,7 +245,7 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
   return (
     <Card className="bg-card/90 backdrop-blur-md">
       <CardHeader>
-        <CardTitle>Template nodes</CardTitle>
+        <CardTitle>Node editor</CardTitle>
         <CardDescription>
           {selectedTemplate
             ? `Grouped editor for ${selectedTemplate.title}.`
@@ -280,6 +314,9 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
             sections.map((section) => (
               <NodeSectionCard
                 key={section.node.id}
+                isOpen={
+                  section.node.nodeType === 'MILESTONE' || openSectionIds.has(section.node.id)
+                }
                 section={section}
                 skills={skills}
                 onAddChild={() =>
@@ -293,6 +330,7 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
                 }
                 onDeleteNode={setNodeToDelete}
                 onEditNode={(node) => setNodeDrawer({ mode: 'edit', node })}
+                onToggleSection={() => toggleSection(section.node.id)}
               />
             ))
           ) : selectedTemplate ? (
@@ -341,74 +379,114 @@ export function AdminTemplateNodesPanel({ selectedTemplate }: AdminTemplateNodes
 }
 
 function NodeSectionCard({
+  isOpen,
   onAddChild,
   onDeleteNode,
   onEditNode,
+  onToggleSection,
   section,
   skills,
 }: {
+  isOpen: boolean;
   onAddChild: () => void;
   onDeleteNode: (node: AdminTemplateNode) => void;
   onEditNode: (node: AdminTemplateNode) => void;
+  onToggleSection: () => void;
   section: TemplateNodeSection;
   skills: AdminSkill[];
 }) {
   const isMilestone = section.node.nodeType === 'MILESTONE';
+  const lessonLabel = `${section.children.length} lesson${section.children.length === 1 ? '' : 's'}`;
+  const summaryContent = (
+    <>
+      <div
+        className={cn(
+          'flex size-9 shrink-0 items-center justify-center rounded-full text-sm font-semibold shadow-sm',
+          isMilestone ? 'text-primary-foreground bg-yellow-500' : 'bg-primary/10 text-primary',
+        )}
+      >
+        {isMilestone ? 'M' : 'G'}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="text-foreground text-sm font-semibold whitespace-normal">
+            {section.node.name}
+          </span>
+          <Badge variant={isMilestone ? 'default' : 'secondary'}>
+            {formatEnumLabel(section.node.nodeType)}
+          </Badge>
+          <Badge variant="outline">{lessonLabel}</Badge>
+        </div>
+        {section.node.description ? (
+          <p className="text-muted-foreground line-clamp-2 text-sm">{section.node.description}</p>
+        ) : null}
+      </div>
+    </>
+  );
 
   return (
     <section
       className={cn(
         'rounded-lg border',
-        isMilestone ? 'border-primary/30 bg-primary/5' : 'border-border bg-background/75',
+        isMilestone
+          ? 'border-yellow-300 bg-yellow-50/90 shadow-sm'
+          : 'border-primary/20 bg-background/90 shadow-sm',
       )}
     >
-      <div className="flex flex-col gap-3 p-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h3 className="text-sm font-semibold">{section.node.name}</h3>
-              <Badge variant={isMilestone ? 'default' : 'secondary'}>
-                {formatEnumLabel(section.node.nodeType)}
-              </Badge>
-              <Badge variant="outline">{section.children.length} lessons</Badge>
-            </div>
-            {section.node.description ? (
-              <p className="text-muted-foreground mt-2 text-sm">{section.node.description}</p>
-            ) : null}
-          </div>
-          <div className="flex shrink-0 flex-wrap gap-2">
-            <Button size="sm" variant="outline" onClick={onAddChild}>
-              Add lesson
-            </Button>
-            <Button size="sm" variant="outline" onClick={() => onEditNode(section.node)}>
-              Edit
-            </Button>
-            <Button size="sm" variant="destructive" onClick={() => onDeleteNode(section.node)}>
-              Delete
-            </Button>
-          </div>
-        </div>
+      <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
+        {isMilestone ? (
+          <div className="flex min-w-0 flex-1 items-center gap-3">{summaryContent}</div>
+        ) : (
+          <button
+            className="focus-visible:border-ring focus-visible:ring-ring/50 flex min-w-0 flex-1 items-center gap-3 rounded-md text-left outline-none focus-visible:ring-3"
+            type="button"
+            aria-expanded={isOpen}
+            onClick={onToggleSection}
+          >
+            {summaryContent}
+            <HugeiconsIcon
+              className={cn('shrink-0 transition-transform', isOpen && 'rotate-180')}
+              data-icon="inline-end"
+              icon={ArrowDown01Icon}
+            />
+          </button>
+        )}
 
-        <Separator />
-
-        <div className="flex flex-col gap-2">
-          {section.children.length > 0 ? (
-            section.children.map((node) => (
-              <LeafNodeRow
-                key={node.id}
-                node={node}
-                skills={skills}
-                onDelete={() => onDeleteNode(node)}
-                onEdit={() => onEditNode(node)}
-              />
-            ))
-          ) : (
-            <p className="text-muted-foreground px-1 py-3 text-sm">
-              No required or optional skills in this section.
-            </p>
-          )}
+        <div className="flex shrink-0 flex-wrap gap-2">
+          <Button size="sm" variant="outline" onClick={onAddChild}>
+            Add lesson
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => onEditNode(section.node)}>
+            Edit
+          </Button>
+          <Button size="sm" variant="destructive" onClick={() => onDeleteNode(section.node)}>
+            Delete
+          </Button>
         </div>
       </div>
+
+      {isOpen ? (
+        <>
+          <Separator />
+          <div className="flex flex-col gap-2 p-3">
+            {section.children.length > 0 ? (
+              section.children.map((node) => (
+                <LeafNodeRow
+                  key={node.id}
+                  node={node}
+                  skills={skills}
+                  onDelete={() => onDeleteNode(node)}
+                  onEdit={() => onEditNode(node)}
+                />
+              ))
+            ) : (
+              <p className="text-muted-foreground px-1 py-3 text-sm">
+                No required or optional skills in this section.
+              </p>
+            )}
+          </div>
+        </>
+      ) : null}
     </section>
   );
 }
@@ -427,7 +505,7 @@ function LeafNodeRow({
   const skillName = skills.find((skill) => skill.id === node.skillId)?.name;
 
   return (
-    <article className="border-border bg-card/80 rounded-md border p-3">
+    <article className="border-border/80 bg-background rounded-md border px-3 py-3 shadow-sm">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
@@ -436,10 +514,12 @@ function LeafNodeRow({
               {formatEnumLabel(node.nodeType)}
             </Badge>
           </div>
-          <p className="text-muted-foreground mt-1 text-xs">
-            {skillName ?? node.skillId ?? 'No skill linked'}
-            {node.estimatedHours === null ? '' : ` - ${node.estimatedHours}h`}
-          </p>
+          <div className="text-muted-foreground mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+            <span>{skillName ?? node.skillId ?? 'No skill linked'}</span>
+            <span>
+              {node.estimatedHours === null ? 'Hours not set' : `${node.estimatedHours} hours`}
+            </span>
+          </div>
         </div>
         <div className="flex shrink-0 gap-2">
           <Button size="sm" variant="outline" onClick={onEdit}>

--- a/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
+++ b/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
@@ -1,0 +1,618 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@repo/design-system/components/ui/alert-dialog';
+import { Badge } from '@repo/design-system/components/ui/badge';
+import { Button } from '@repo/design-system/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@repo/design-system/components/ui/card';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@repo/design-system/components/ui/drawer';
+import { Field, FieldError, FieldGroup, FieldLabel } from '@repo/design-system/components/ui/field';
+import { Input } from '@repo/design-system/components/ui/input';
+import { Skeleton } from '@repo/design-system/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@repo/design-system/components/ui/table';
+import { toast } from '@repo/design-system/lib/toast';
+import { cn } from '@repo/design-system/lib/utils';
+import { useDeferredValue, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import type {
+  AdminTemplate,
+  AdminTemplatePayload,
+  AdminTemplatesListResponse,
+  RoleCategory,
+} from '@/types/admin-content';
+
+import { adminContentService, getApiErrorMessage } from '@/services/admin-content.service';
+import {
+  adminTemplateFormSchema,
+  ROLE_CATEGORY_VALUES,
+  type AdminTemplateFormValues,
+} from '@/validations/admin-content.schema';
+
+const PER_PAGE = 10;
+const EMPTY_TEMPLATES: AdminTemplate[] = [];
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+});
+
+const CONTROL_CLASS_NAME =
+  'border-border focus-visible:border-border bg-background text-foreground disabled:border-disabled disabled:bg-background disabled:text-disabled disabled:placeholder:text-disabled placeholder:text-muted-foreground/70 focus-visible:ring-ring min-h-10 w-full min-w-0 rounded-md border px-3 py-2.5 text-base shadow-[0_1px_2px_0_rgba(139,92,246,0.10)] transition-all outline-none focus-visible:shadow-none focus-visible:ring-2 disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20';
+
+type RoleFilter = '' | RoleCategory;
+
+type TemplateDrawerState =
+  | {
+      mode: 'create';
+      template?: undefined;
+    }
+  | {
+      mode: 'edit';
+      template: AdminTemplate;
+    };
+
+export function AdminTemplatesContent() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>('');
+  const [page, setPage] = useState(1);
+  const [templatesResponse, setTemplatesResponse] = useState<AdminTemplatesListResponse | null>(
+    null,
+  );
+  const [isLoadingTemplates, setIsLoadingTemplates] = useState(true);
+  const [templatesError, setTemplatesError] = useState<string | null>(null);
+  const [templatesRefreshKey, setTemplatesRefreshKey] = useState(0);
+  const [templateDrawer, setTemplateDrawer] = useState<TemplateDrawerState | null>(null);
+  const [templateToDelete, setTemplateToDelete] = useState<AdminTemplate | null>(null);
+  const [isDeletingTemplate, setIsDeletingTemplate] = useState(false);
+  const deferredSearchTerm = useDeferredValue(searchTerm.trim());
+
+  const templates = templatesResponse?.data ?? EMPTY_TEMPLATES;
+  const templatesMeta = templatesResponse?.meta;
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    setIsLoadingTemplates(true);
+    setTemplatesError(null);
+
+    void adminContentService
+      .listTemplates({
+        page,
+        perPage: PER_PAGE,
+        q: deferredSearchTerm || undefined,
+        roleCategory: roleFilter || undefined,
+      })
+      .then((response) => {
+        if (!isCurrent) return;
+        setTemplatesResponse(response);
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) return;
+        setTemplatesResponse(null);
+        setTemplatesError(getApiErrorMessage(error, 'Unable to load templates.'));
+      })
+      .finally(() => {
+        if (isCurrent) {
+          setIsLoadingTemplates(false);
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [deferredSearchTerm, page, roleFilter, templatesRefreshKey]);
+
+  const refreshTemplates = () => {
+    setTemplatesRefreshKey((current) => current + 1);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    setPage(1);
+  };
+
+  const handleRoleFilterChange = (value: RoleFilter) => {
+    setRoleFilter(value);
+    setPage(1);
+  };
+
+  const handleSubmitTemplate = async (payload: AdminTemplatePayload, template?: AdminTemplate) => {
+    if (template) {
+      await adminContentService.updateTemplate(template.id, payload);
+      toast.success('Template updated');
+    } else {
+      await adminContentService.createTemplate(payload);
+      toast.success('Template created');
+    }
+
+    refreshTemplates();
+  };
+
+  const handleDeleteTemplate = async () => {
+    if (!templateToDelete) return;
+
+    setIsDeletingTemplate(true);
+
+    try {
+      await adminContentService.deleteTemplate(templateToDelete.id);
+      toast.success('Template deleted');
+      setTemplateToDelete(null);
+      refreshTemplates();
+    } catch (error) {
+      toast.error('Template deletion failed', {
+        description: getApiErrorMessage(error, 'Unable to delete this template.'),
+      });
+    } finally {
+      setIsDeletingTemplate(false);
+    }
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <section className="border-border/70 bg-card/90 rounded-3xl border p-5 shadow-sm backdrop-blur-md">
+        <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+          <div className="flex max-w-3xl flex-col gap-2">
+            <Badge variant="outline" className="w-fit">
+              Phase 2
+            </Badge>
+            <div className="flex flex-col gap-1">
+              <h1 className="font-heading text-foreground text-3xl leading-tight sm:text-4xl">
+                Roadmap templates
+              </h1>
+              <p className="text-muted-foreground text-sm sm:text-base">
+                Manage template metadata for the public roadmap catalog.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => refreshTemplates()}>
+              Refresh
+            </Button>
+            <Button onClick={() => setTemplateDrawer({ mode: 'create' })}>Create template</Button>
+          </div>
+        </div>
+      </section>
+
+      <Card className="bg-card/90 backdrop-blur-md">
+        <CardHeader>
+          <CardTitle>Template catalog</CardTitle>
+          <CardDescription>
+            Empty templates are included so metadata can be prepared before node editing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px]">
+            <Field>
+              <FieldLabel className="sr-only" htmlFor="template-search">
+                Search templates
+              </FieldLabel>
+              <Input
+                id="template-search"
+                placeholder="Search templates..."
+                value={searchTerm}
+                onChange={(event) => handleSearchChange(event.target.value)}
+              />
+            </Field>
+            <Field>
+              <FieldLabel className="sr-only" htmlFor="template-role-filter">
+                Filter by role category
+              </FieldLabel>
+              <NativeSelect
+                id="template-role-filter"
+                value={roleFilter}
+                onChange={(event) => handleRoleFilterChange(event.target.value as RoleFilter)}
+              >
+                <option value="">All role categories</option>
+                {ROLE_CATEGORY_VALUES.map((category) => (
+                  <option key={category} value={category}>
+                    {formatEnumLabel(category)}
+                  </option>
+                ))}
+              </NativeSelect>
+            </Field>
+          </div>
+
+          {templatesError ? (
+            <InlineNotice title="Templates unavailable" tone="error" description={templatesError} />
+          ) : null}
+
+          <div className="overflow-hidden rounded-2xl border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Template</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Weeks</TableHead>
+                  <TableHead>Updated</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoadingTemplates ? (
+                  <TablePlaceholder rows={5} />
+                ) : templates.length > 0 ? (
+                  templates.map((template) => (
+                    <TableRow key={template.id}>
+                      <TableCell className="min-w-72 whitespace-normal">
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium">{template.title}</span>
+                          <span className="text-muted-foreground line-clamp-2 text-xs">
+                            {template.description || 'No description yet.'}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">{formatEnumLabel(template.roleCategory)}</Badge>
+                      </TableCell>
+                      <TableCell>{formatWeeks(template.estimatedWeeks)}</TableCell>
+                      <TableCell>{formatDate(template.updatedAt)}</TableCell>
+                      <TableCell>
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setTemplateDrawer({ mode: 'edit', template })}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => setTemplateToDelete(template)}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell className="text-muted-foreground h-32 text-center" colSpan={5}>
+                      No templates match the current filters.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-muted-foreground text-sm">
+              {templatesMeta
+                ? `${templatesMeta.total} templates, page ${templatesMeta.page} of ${Math.max(templatesMeta.totalPages, 1)}`
+                : 'Loading templates...'}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isLoadingTemplates || page <= 1}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={
+                  isLoadingTemplates ||
+                  !templatesMeta ||
+                  templatesMeta.totalPages === 0 ||
+                  page >= templatesMeta.totalPages
+                }
+                onClick={() => setPage((current) => current + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <TemplateFormDrawer
+        drawer={templateDrawer}
+        onOpenChange={(open) => {
+          if (!open) setTemplateDrawer(null);
+        }}
+        onSubmit={handleSubmitTemplate}
+      />
+
+      <ConfirmDeleteDialog
+        title="Delete template"
+        confirmLabel="Delete template"
+        description={
+          templateToDelete
+            ? `Delete "${templateToDelete.title}"? This also removes its template nodes.`
+            : ''
+        }
+        isDeleting={isDeletingTemplate}
+        onConfirm={handleDeleteTemplate}
+        open={!!templateToDelete}
+        onOpenChange={(open) => {
+          if (!open) setTemplateToDelete(null);
+        }}
+      />
+    </div>
+  );
+}
+
+function TemplateFormDrawer({
+  drawer,
+  onOpenChange,
+  onSubmit,
+}: {
+  drawer: TemplateDrawerState | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: AdminTemplatePayload, template?: AdminTemplate) => Promise<void>;
+}) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const template = drawer?.template;
+  const form = useForm<AdminTemplateFormValues>({
+    defaultValues: getTemplateFormDefaults(template),
+    resolver: zodResolver(adminTemplateFormSchema),
+  });
+  const errors = form.formState.errors;
+  const isOpen = !!drawer;
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset(getTemplateFormDefaults(template));
+    }
+  }, [form, isOpen, template]);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setIsSubmitting(true);
+
+    try {
+      await onSubmit(toTemplatePayload(values), template);
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(template ? 'Template update failed' : 'Template creation failed', {
+        description: getApiErrorMessage(error, 'Please check the template details and try again.'),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  return (
+    <Drawer direction="right" open={isOpen} onOpenChange={onOpenChange}>
+      <DrawerContent className="sm:max-w-xl">
+        <form className="flex min-h-0 flex-1 flex-col" noValidate onSubmit={handleSubmit}>
+          <DrawerHeader>
+            <DrawerTitle>{template ? 'Edit template' : 'Create template'}</DrawerTitle>
+            <DrawerDescription>
+              Metadata controls how templates appear in the catalog and recommendations.
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="scrollbar-thin flex-1 overflow-y-auto px-4">
+            <FieldGroup>
+              <Field data-invalid={!!errors.title}>
+                <FieldLabel htmlFor="template-title">Title</FieldLabel>
+                <Input
+                  id="template-title"
+                  aria-invalid={!!errors.title}
+                  {...form.register('title')}
+                />
+                <FieldError errors={[errors.title]} />
+              </Field>
+
+              <Field data-invalid={!!errors.roleCategory}>
+                <FieldLabel htmlFor="template-role-category">Role category</FieldLabel>
+                <NativeSelect
+                  id="template-role-category"
+                  aria-invalid={!!errors.roleCategory}
+                  {...form.register('roleCategory')}
+                >
+                  {ROLE_CATEGORY_VALUES.map((category) => (
+                    <option key={category} value={category}>
+                      {formatEnumLabel(category)}
+                    </option>
+                  ))}
+                </NativeSelect>
+                <FieldError errors={[errors.roleCategory]} />
+              </Field>
+
+              <Field data-invalid={!!errors.estimatedWeeks}>
+                <FieldLabel htmlFor="template-estimated-weeks">Estimated weeks</FieldLabel>
+                <Input
+                  id="template-estimated-weeks"
+                  placeholder="Optional"
+                  inputMode="numeric"
+                  aria-invalid={!!errors.estimatedWeeks}
+                  {...form.register('estimatedWeeks')}
+                />
+                <FieldError errors={[errors.estimatedWeeks]} />
+              </Field>
+
+              <Field data-invalid={!!errors.description}>
+                <FieldLabel htmlFor="template-description">Description</FieldLabel>
+                <TextareaControl
+                  id="template-description"
+                  placeholder="Describe the template path."
+                  aria-invalid={!!errors.description}
+                  rows={6}
+                  {...form.register('description')}
+                />
+                <FieldError errors={[errors.description]} />
+              </Field>
+            </FieldGroup>
+          </div>
+          <DrawerFooter>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Saving...' : 'Save template'}
+            </Button>
+            <DrawerClose asChild>
+              <Button variant="outline" type="button">
+                Cancel
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </form>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function ConfirmDeleteDialog({
+  confirmLabel,
+  description,
+  isDeleting,
+  onConfirm,
+  onOpenChange,
+  open,
+  title,
+}: {
+  confirmLabel: string;
+  description: string;
+  isDeleting: boolean;
+  onConfirm: () => Promise<void>;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  title: string;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            type="button"
+            disabled={isDeleting}
+            onClick={() => {
+              void onConfirm();
+            }}
+          >
+            {isDeleting ? 'Deleting...' : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function InlineNotice({
+  description,
+  title,
+  tone = 'default',
+}: {
+  description: string;
+  title: string;
+  tone?: 'default' | 'error';
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl border p-4',
+        tone === 'error' ? 'border-destructive/30 bg-destructive/5' : 'border-border bg-muted/30',
+      )}
+    >
+      <p className="font-medium">{title}</p>
+      <p className="text-muted-foreground mt-1 text-sm">{description}</p>
+    </div>
+  );
+}
+
+function TablePlaceholder({ rows }: { rows: number }) {
+  return Array.from({ length: rows }).map((_, index) => (
+    <TableRow key={index}>
+      <TableCell className="h-16" colSpan={5}>
+        <Skeleton className="h-4 w-full max-w-180 rounded-full" />
+      </TableCell>
+    </TableRow>
+  ));
+}
+
+function NativeSelect({ className, ...props }: ComponentProps<'select'>) {
+  return <select className={cn(CONTROL_CLASS_NAME, className)} {...props} />;
+}
+
+function TextareaControl({ className, ...props }: ComponentProps<'textarea'>) {
+  return <textarea className={cn(CONTROL_CLASS_NAME, 'min-h-28 resize-y', className)} {...props} />;
+}
+
+function getTemplateFormDefaults(template?: AdminTemplate): AdminTemplateFormValues {
+  return {
+    description: template?.description ?? '',
+    estimatedWeeks:
+      template?.estimatedWeeks === null || template?.estimatedWeeks === undefined
+        ? ''
+        : String(template.estimatedWeeks),
+    roleCategory: template?.roleCategory ?? 'WEB_DEVELOPMENT',
+    title: template?.title ?? '',
+  };
+}
+
+function toTemplatePayload(values: AdminTemplateFormValues): AdminTemplatePayload {
+  const estimatedWeeks = values.estimatedWeeks.trim();
+
+  return {
+    description: values.description.trim(),
+    estimatedWeeks: estimatedWeeks ? Number(estimatedWeeks) : null,
+    roleCategory: values.roleCategory,
+    title: values.title.trim(),
+  };
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+
+  return Number.isNaN(date.getTime()) ? 'Unknown' : DATE_FORMATTER.format(date);
+}
+
+function formatEnumLabel(value: RoleCategory): string {
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function formatWeeks(value: null | number): string {
+  if (value === null) {
+    return 'Not set';
+  }
+
+  return `${value} week${value === 1 ? '' : 's'}`;
+}

--- a/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
+++ b/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
@@ -61,6 +61,8 @@ import {
   type AdminTemplateFormValues,
 } from '@/validations/admin-content.schema';
 
+import { AdminTemplateNodesPanel } from './admin-template-nodes-panel';
+
 const PER_PAGE = 10;
 const EMPTY_TEMPLATES: AdminTemplate[] = [];
 
@@ -92,6 +94,7 @@ export function AdminTemplatesContent() {
   const [templatesResponse, setTemplatesResponse] = useState<AdminTemplatesListResponse | null>(
     null,
   );
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
   const [isLoadingTemplates, setIsLoadingTemplates] = useState(true);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [templatesRefreshKey, setTemplatesRefreshKey] = useState(0);
@@ -102,6 +105,7 @@ export function AdminTemplatesContent() {
 
   const templates = templatesResponse?.data ?? EMPTY_TEMPLATES;
   const templatesMeta = templatesResponse?.meta;
+  const selectedTemplate = templates.find((template) => template.id === selectedTemplateId) ?? null;
 
   useEffect(() => {
     let isCurrent = true;
@@ -136,6 +140,17 @@ export function AdminTemplatesContent() {
     };
   }, [deferredSearchTerm, page, roleFilter, templatesRefreshKey]);
 
+  useEffect(() => {
+    if (templates.length === 0) {
+      setSelectedTemplateId(null);
+      return;
+    }
+
+    if (!selectedTemplateId || !templates.some((template) => template.id === selectedTemplateId)) {
+      setSelectedTemplateId(templates[0]?.id ?? null);
+    }
+  }, [selectedTemplateId, templates]);
+
   const refreshTemplates = () => {
     setTemplatesRefreshKey((current) => current + 1);
   };
@@ -151,14 +166,17 @@ export function AdminTemplatesContent() {
   };
 
   const handleSubmitTemplate = async (payload: AdminTemplatePayload, template?: AdminTemplate) => {
+    const savedTemplate = template
+      ? await adminContentService.updateTemplate(template.id, payload)
+      : await adminContentService.createTemplate(payload);
+
     if (template) {
-      await adminContentService.updateTemplate(template.id, payload);
       toast.success('Template updated');
     } else {
-      await adminContentService.createTemplate(payload);
       toast.success('Template created');
     }
 
+    setSelectedTemplateId(savedTemplate.id);
     refreshTemplates();
   };
 
@@ -170,6 +188,9 @@ export function AdminTemplatesContent() {
     try {
       await adminContentService.deleteTemplate(templateToDelete.id);
       toast.success('Template deleted');
+      if (templateToDelete.id === selectedTemplateId) {
+        setSelectedTemplateId(null);
+      }
       setTemplateToDelete(null);
       refreshTemplates();
     } catch (error) {
@@ -187,14 +208,14 @@ export function AdminTemplatesContent() {
         <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
           <div className="flex max-w-3xl flex-col gap-2">
             <Badge variant="outline" className="w-fit">
-              Phase 2
+              Phase 2-3
             </Badge>
             <div className="flex flex-col gap-1">
               <h1 className="font-heading text-foreground text-3xl leading-tight sm:text-4xl">
                 Roadmap templates
               </h1>
               <p className="text-muted-foreground text-sm sm:text-base">
-                Manage template metadata for the public roadmap catalog.
+                Manage template metadata and grouped node lists for the public roadmap catalog.
               </p>
             </div>
           </div>
@@ -208,142 +229,160 @@ export function AdminTemplatesContent() {
         </div>
       </section>
 
-      <Card className="bg-card/90 backdrop-blur-md">
-        <CardHeader>
-          <CardTitle>Template catalog</CardTitle>
-          <CardDescription>
-            Empty templates are included so metadata can be prepared before node editing.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px]">
-            <Field>
-              <FieldLabel className="sr-only" htmlFor="template-search">
-                Search templates
-              </FieldLabel>
-              <Input
-                id="template-search"
-                placeholder="Search templates..."
-                value={searchTerm}
-                onChange={(event) => handleSearchChange(event.target.value)}
+      <div className="grid min-w-0 gap-4 2xl:grid-cols-[minmax(0,1.15fr)_minmax(420px,0.85fr)]">
+        <Card className="bg-card/90 backdrop-blur-md">
+          <CardHeader>
+            <CardTitle>Template catalog</CardTitle>
+            <CardDescription>
+              Empty templates are included so metadata can be prepared before node editing.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px]">
+              <Field>
+                <FieldLabel className="sr-only" htmlFor="template-search">
+                  Search templates
+                </FieldLabel>
+                <Input
+                  id="template-search"
+                  placeholder="Search templates..."
+                  value={searchTerm}
+                  onChange={(event) => handleSearchChange(event.target.value)}
+                />
+              </Field>
+              <Field>
+                <FieldLabel className="sr-only" htmlFor="template-role-filter">
+                  Filter by role category
+                </FieldLabel>
+                <NativeSelect
+                  id="template-role-filter"
+                  value={roleFilter}
+                  onChange={(event) => handleRoleFilterChange(event.target.value as RoleFilter)}
+                >
+                  <option value="">All role categories</option>
+                  {ROLE_CATEGORY_VALUES.map((category) => (
+                    <option key={category} value={category}>
+                      {formatEnumLabel(category)}
+                    </option>
+                  ))}
+                </NativeSelect>
+              </Field>
+            </div>
+
+            {templatesError ? (
+              <InlineNotice
+                title="Templates unavailable"
+                tone="error"
+                description={templatesError}
               />
-            </Field>
-            <Field>
-              <FieldLabel className="sr-only" htmlFor="template-role-filter">
-                Filter by role category
-              </FieldLabel>
-              <NativeSelect
-                id="template-role-filter"
-                value={roleFilter}
-                onChange={(event) => handleRoleFilterChange(event.target.value as RoleFilter)}
-              >
-                <option value="">All role categories</option>
-                {ROLE_CATEGORY_VALUES.map((category) => (
-                  <option key={category} value={category}>
-                    {formatEnumLabel(category)}
-                  </option>
-                ))}
-              </NativeSelect>
-            </Field>
-          </div>
+            ) : null}
 
-          {templatesError ? (
-            <InlineNotice title="Templates unavailable" tone="error" description={templatesError} />
-          ) : null}
-
-          <div className="overflow-hidden rounded-2xl border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Template</TableHead>
-                  <TableHead>Category</TableHead>
-                  <TableHead>Weeks</TableHead>
-                  <TableHead>Updated</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {isLoadingTemplates ? (
-                  <TablePlaceholder rows={5} />
-                ) : templates.length > 0 ? (
-                  templates.map((template) => (
-                    <TableRow key={template.id}>
-                      <TableCell className="min-w-72 whitespace-normal">
-                        <div className="flex flex-col gap-1">
-                          <span className="font-medium">{template.title}</span>
-                          <span className="text-muted-foreground line-clamp-2 text-xs">
-                            {template.description || 'No description yet.'}
-                          </span>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="secondary">{formatEnumLabel(template.roleCategory)}</Badge>
-                      </TableCell>
-                      <TableCell>{formatWeeks(template.estimatedWeeks)}</TableCell>
-                      <TableCell>{formatDate(template.updatedAt)}</TableCell>
-                      <TableCell>
-                        <div className="flex justify-end gap-2">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setTemplateDrawer({ mode: 'edit', template })}
+            <div className="overflow-hidden rounded-2xl border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Template</TableHead>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Weeks</TableHead>
+                    <TableHead>Updated</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {isLoadingTemplates ? (
+                    <TablePlaceholder rows={5} />
+                  ) : templates.length > 0 ? (
+                    templates.map((template) => (
+                      <TableRow
+                        key={template.id}
+                        className="cursor-pointer"
+                        data-state={template.id === selectedTemplateId ? 'selected' : undefined}
+                        onClick={() => setSelectedTemplateId(template.id)}
+                      >
+                        <TableCell className="min-w-72 whitespace-normal">
+                          <div className="flex flex-col gap-1">
+                            <span className="font-medium">{template.title}</span>
+                            <span className="text-muted-foreground line-clamp-2 text-xs">
+                              {template.description || 'No description yet.'}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">
+                            {formatEnumLabel(template.roleCategory)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{formatWeeks(template.estimatedWeeks)}</TableCell>
+                        <TableCell>{formatDate(template.updatedAt)}</TableCell>
+                        <TableCell>
+                          <div
+                            className="flex justify-end gap-2"
+                            onClick={(event) => event.stopPropagation()}
                           >
-                            Edit
-                          </Button>
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => setTemplateToDelete(template)}
-                          >
-                            Delete
-                          </Button>
-                        </div>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setTemplateDrawer({ mode: 'edit', template })}
+                            >
+                              Edit
+                            </Button>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => setTemplateToDelete(template)}
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell className="text-muted-foreground h-32 text-center" colSpan={5}>
+                        No templates match the current filters.
                       </TableCell>
                     </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell className="text-muted-foreground h-32 text-center" colSpan={5}>
-                      No templates match the current filters.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
-
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-muted-foreground text-sm">
-              {templatesMeta
-                ? `${templatesMeta.total} templates, page ${templatesMeta.page} of ${Math.max(templatesMeta.totalPages, 1)}`
-                : 'Loading templates...'}
-            </p>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={isLoadingTemplates || page <= 1}
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-              >
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={
-                  isLoadingTemplates ||
-                  !templatesMeta ||
-                  templatesMeta.totalPages === 0 ||
-                  page >= templatesMeta.totalPages
-                }
-                onClick={() => setPage((current) => current + 1)}
-              >
-                Next
-              </Button>
+                  )}
+                </TableBody>
+              </Table>
             </div>
-          </div>
-        </CardContent>
-      </Card>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-muted-foreground text-sm">
+                {templatesMeta
+                  ? `${templatesMeta.total} templates, page ${templatesMeta.page} of ${Math.max(templatesMeta.totalPages, 1)}`
+                  : 'Loading templates...'}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isLoadingTemplates || page <= 1}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={
+                    isLoadingTemplates ||
+                    !templatesMeta ||
+                    templatesMeta.totalPages === 0 ||
+                    page >= templatesMeta.totalPages
+                  }
+                  onClick={() => setPage((current) => current + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <AdminTemplateNodesPanel selectedTemplate={selectedTemplate} />
+      </div>
 
       <TemplateFormDrawer
         drawer={templateDrawer}

--- a/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
+++ b/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { Route } from 'next';
 import type { ComponentProps } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -44,6 +45,7 @@ import {
 } from '@repo/design-system/components/ui/table';
 import { toast } from '@repo/design-system/lib/toast';
 import { cn } from '@repo/design-system/lib/utils';
+import Link from 'next/link';
 import { useDeferredValue, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -60,8 +62,6 @@ import {
   ROLE_CATEGORY_VALUES,
   type AdminTemplateFormValues,
 } from '@/validations/admin-content.schema';
-
-import { AdminTemplateNodesPanel } from './admin-template-nodes-panel';
 
 const PER_PAGE = 10;
 const EMPTY_TEMPLATES: AdminTemplate[] = [];
@@ -105,7 +105,6 @@ export function AdminTemplatesContent() {
 
   const templates = templatesResponse?.data ?? EMPTY_TEMPLATES;
   const templatesMeta = templatesResponse?.meta;
-  const selectedTemplate = templates.find((template) => template.id === selectedTemplateId) ?? null;
 
   useEffect(() => {
     let isCurrent = true;
@@ -212,7 +211,8 @@ export function AdminTemplatesContent() {
                 Roadmap templates
               </h1>
               <p className="text-muted-foreground text-sm sm:text-base">
-                Manage template metadata and grouped node lists for the public roadmap catalog.
+                Manage template metadata for the public roadmap catalog. Open a template to edit its
+                grouped node list.
               </p>
             </div>
           </div>
@@ -226,160 +226,159 @@ export function AdminTemplatesContent() {
         </div>
       </section>
 
-      <div className="grid min-w-0 gap-4 2xl:grid-cols-[minmax(0,1.15fr)_minmax(420px,0.85fr)]">
-        <Card className="bg-card/90 backdrop-blur-md">
-          <CardHeader>
-            <CardTitle>Template catalog</CardTitle>
-            <CardDescription>
-              Empty templates are included so metadata can be prepared before node editing.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-4">
-            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px]">
-              <Field>
-                <FieldLabel className="sr-only" htmlFor="template-search">
-                  Search templates
-                </FieldLabel>
-                <Input
-                  id="template-search"
-                  placeholder="Search templates..."
-                  value={searchTerm}
-                  onChange={(event) => handleSearchChange(event.target.value)}
-                />
-              </Field>
-              <Field>
-                <FieldLabel className="sr-only" htmlFor="template-role-filter">
-                  Filter by role category
-                </FieldLabel>
-                <NativeSelect
-                  id="template-role-filter"
-                  value={roleFilter}
-                  onChange={(event) => handleRoleFilterChange(event.target.value as RoleFilter)}
-                >
-                  <option value="">All role categories</option>
-                  {ROLE_CATEGORY_VALUES.map((category) => (
-                    <option key={category} value={category}>
-                      {formatEnumLabel(category)}
-                    </option>
-                  ))}
-                </NativeSelect>
-              </Field>
-            </div>
-
-            {templatesError ? (
-              <InlineNotice
-                title="Templates unavailable"
-                tone="error"
-                description={templatesError}
+      <Card className="bg-card/90 backdrop-blur-md">
+        <CardHeader>
+          <CardTitle>Template catalog</CardTitle>
+          <CardDescription>
+            Empty templates are included so metadata can be prepared before node editing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px]">
+            <Field>
+              <FieldLabel className="sr-only" htmlFor="template-search">
+                Search templates
+              </FieldLabel>
+              <Input
+                id="template-search"
+                placeholder="Search templates..."
+                value={searchTerm}
+                onChange={(event) => handleSearchChange(event.target.value)}
               />
-            ) : null}
+            </Field>
+            <Field>
+              <FieldLabel className="sr-only" htmlFor="template-role-filter">
+                Filter by role category
+              </FieldLabel>
+              <NativeSelect
+                id="template-role-filter"
+                value={roleFilter}
+                onChange={(event) => handleRoleFilterChange(event.target.value as RoleFilter)}
+              >
+                <option value="">All role categories</option>
+                {ROLE_CATEGORY_VALUES.map((category) => (
+                  <option key={category} value={category}>
+                    {formatEnumLabel(category)}
+                  </option>
+                ))}
+              </NativeSelect>
+            </Field>
+          </div>
 
-            <div className="overflow-hidden rounded-2xl border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Template</TableHead>
-                    <TableHead>Category</TableHead>
-                    <TableHead>Weeks</TableHead>
-                    <TableHead>Updated</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {isLoadingTemplates ? (
-                    <TablePlaceholder rows={5} />
-                  ) : templates.length > 0 ? (
-                    templates.map((template) => (
-                      <TableRow
-                        key={template.id}
-                        className="cursor-pointer"
-                        data-state={template.id === selectedTemplateId ? 'selected' : undefined}
-                        onClick={() => setSelectedTemplateId(template.id)}
-                      >
-                        <TableCell className="min-w-72 whitespace-normal">
-                          <div className="flex flex-col gap-1">
-                            <span className="font-medium">{template.title}</span>
-                            <span className="text-muted-foreground line-clamp-2 text-xs">
-                              {template.description || 'No description yet.'}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="secondary">
-                            {formatEnumLabel(template.roleCategory)}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>{formatWeeks(template.estimatedWeeks)}</TableCell>
-                        <TableCell>{formatDate(template.updatedAt)}</TableCell>
-                        <TableCell>
-                          <div
-                            className="flex justify-end gap-2"
-                            onClick={(event) => event.stopPropagation()}
+          {templatesError ? (
+            <InlineNotice title="Templates unavailable" tone="error" description={templatesError} />
+          ) : null}
+
+          <div className="overflow-hidden rounded-2xl border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Template</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Weeks</TableHead>
+                  <TableHead>Updated</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoadingTemplates ? (
+                  <TablePlaceholder rows={5} />
+                ) : templates.length > 0 ? (
+                  templates.map((template) => (
+                    <TableRow
+                      key={template.id}
+                      className="cursor-pointer"
+                      data-state={template.id === selectedTemplateId ? 'selected' : undefined}
+                      onClick={() => setSelectedTemplateId(template.id)}
+                    >
+                      <TableCell className="min-w-72 whitespace-normal">
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium">{template.title}</span>
+                          <span className="text-muted-foreground line-clamp-2 text-xs">
+                            {template.description || 'No description yet.'}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">{formatEnumLabel(template.roleCategory)}</Badge>
+                      </TableCell>
+                      <TableCell>{formatWeeks(template.estimatedWeeks)}</TableCell>
+                      <TableCell>{formatDate(template.updatedAt)}</TableCell>
+                      <TableCell>
+                        <div
+                          className="flex flex-wrap justify-end gap-2"
+                          onClick={(event) => event.stopPropagation()}
+                        >
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            render={
+                              <Link href={`/admin/templates/${template.id}` as Route<string>}>
+                                Manage nodes
+                              </Link>
+                            }
+                          />
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setTemplateDrawer({ mode: 'edit', template })}
                           >
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setTemplateDrawer({ mode: 'edit', template })}
-                            >
-                              Edit
-                            </Button>
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => setTemplateToDelete(template)}
-                            >
-                              Delete
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  ) : (
-                    <TableRow>
-                      <TableCell className="text-muted-foreground h-32 text-center" colSpan={5}>
-                        No templates match the current filters.
+                            Edit
+                          </Button>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => setTemplateToDelete(template)}
+                          >
+                            Delete
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </div>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell className="text-muted-foreground h-32 text-center" colSpan={5}>
+                      No templates match the current filters.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
 
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-muted-foreground text-sm">
-                {templatesMeta
-                  ? `${templatesMeta.total} templates, page ${templatesMeta.page} of ${Math.max(templatesMeta.totalPages, 1)}`
-                  : 'Loading templates...'}
-              </p>
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={isLoadingTemplates || page <= 1}
-                  onClick={() => setPage((current) => Math.max(1, current - 1))}
-                >
-                  Previous
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={
-                    isLoadingTemplates ||
-                    !templatesMeta ||
-                    templatesMeta.totalPages === 0 ||
-                    page >= templatesMeta.totalPages
-                  }
-                  onClick={() => setPage((current) => current + 1)}
-                >
-                  Next
-                </Button>
-              </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-muted-foreground text-sm">
+              {templatesMeta
+                ? `${templatesMeta.total} templates, page ${templatesMeta.page} of ${Math.max(templatesMeta.totalPages, 1)}`
+                : 'Loading templates...'}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isLoadingTemplates || page <= 1}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={
+                  isLoadingTemplates ||
+                  !templatesMeta ||
+                  templatesMeta.totalPages === 0 ||
+                  page >= templatesMeta.totalPages
+                }
+                onClick={() => setPage((current) => current + 1)}
+              >
+                Next
+              </Button>
             </div>
-          </CardContent>
-        </Card>
-
-        <AdminTemplateNodesPanel selectedTemplate={selectedTemplate} />
-      </div>
+          </div>
+        </CardContent>
+      </Card>
 
       <TemplateFormDrawer
         drawer={templateDrawer}

--- a/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
+++ b/apps/web/app/(admin)/admin/templates/_components/admin-templates-content.tsx
@@ -207,9 +207,6 @@ export function AdminTemplatesContent() {
       <section className="border-border/70 bg-card/90 rounded-3xl border p-5 shadow-sm backdrop-blur-md">
         <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
           <div className="flex max-w-3xl flex-col gap-2">
-            <Badge variant="outline" className="w-fit">
-              Phase 2-3
-            </Badge>
             <div className="flex flex-col gap-1">
               <h1 className="font-heading text-foreground text-3xl leading-tight sm:text-4xl">
                 Roadmap templates

--- a/apps/web/app/(admin)/admin/templates/page.tsx
+++ b/apps/web/app/(admin)/admin/templates/page.tsx
@@ -1,0 +1,5 @@
+import { AdminTemplatesContent } from './_components/admin-templates-content';
+
+export default function AdminTemplatesPage() {
+  return <AdminTemplatesContent />;
+}

--- a/apps/web/app/(full-layout)/dashboard/_components/dashboard-content.tsx
+++ b/apps/web/app/(full-layout)/dashboard/_components/dashboard-content.tsx
@@ -33,6 +33,10 @@ function getDefaultFocusRoadmap(roadmaps: DashboardRoadmap[]): DashboardRoadmap 
   );
 }
 
+function getActiveRoadmap(roadmaps: DashboardRoadmap[]): DashboardRoadmap | null {
+  return roadmaps.find((roadmap) => roadmap.startedAt !== null) ?? null;
+}
+
 function DashboardSkeleton() {
   return (
     <div className="grid gap-4 xl:grid-cols-[320px_minmax(0,1fr)]">
@@ -59,7 +63,7 @@ function DashboardSkeleton() {
 }
 
 export function DashboardContent() {
-  const { dashboard, errorMessage, isLoading, refreshDashboard } = useDashboard();
+  const { dashboard, errorMessage, isLoading, refreshDashboard, updateDashboard } = useDashboard();
   const [selectedRoadmapId, setSelectedRoadmapId] = useState<null | string>(null);
   const roadmaps = dashboard?.roadmaps ?? EMPTY_ACTIVE_ROADMAPS;
   const defaultFocusRoadmap = useMemo(() => getDefaultFocusRoadmap(roadmaps), [roadmaps]);
@@ -68,6 +72,27 @@ export function DashboardContent() {
   const hasAnyRoadmap = dashboard ? dashboard.roadmaps.length > 0 : false;
 
   const handleRemoveRoadmap = async (roadmap: DashboardRoadmap): Promise<boolean> => {
+    const previousDashboard = dashboard;
+    const previousSelectedRoadmapId = selectedRoadmap?.roadmapId ?? selectedRoadmapId;
+
+    updateDashboard((currentDashboard) => {
+      if (!currentDashboard) return currentDashboard;
+
+      const remainingRoadmaps = currentDashboard.roadmaps.filter(
+        (dashboardRoadmap) => dashboardRoadmap.roadmapId !== roadmap.roadmapId,
+      );
+
+      return {
+        ...currentDashboard,
+        activeRoadmap: getActiveRoadmap(remainingRoadmaps),
+        roadmaps: remainingRoadmaps,
+      };
+    });
+
+    if (selectedRoadmap?.roadmapId === roadmap.roadmapId) {
+      setSelectedRoadmapId(null);
+    }
+
     try {
       if (roadmap.isTemplate) {
         await roadmapService.deleteTemplateProgress(roadmap.roadmapId);
@@ -77,13 +102,12 @@ export function DashboardContent() {
         toast.success('Roadmap deleted successfully');
       }
 
-      if (selectedRoadmapId === roadmap.roadmapId) {
-        setSelectedRoadmapId(null);
-      }
-
-      await refreshDashboard();
+      void refreshDashboard({ silent: true });
       return true;
     } catch (error) {
+      updateDashboard(() => previousDashboard);
+      setSelectedRoadmapId(previousSelectedRoadmapId);
+
       if (roadmap.isTemplate && isAxiosError(error) && error.response?.status === 409) {
         toast.error('Learning progress cannot be deleted while a milestone submission is running.');
       } else {
@@ -138,7 +162,7 @@ export function DashboardContent() {
                 <h1 className="text-heading text-2xl">Dashboard failed to load</h1>
                 <p className="text-muted-foreground text-sm">{errorMessage}</p>
               </div>
-              <Button type="button" onClick={refreshDashboard}>
+              <Button type="button" onClick={() => void refreshDashboard()}>
                 <HugeiconsIcon data-icon="inline-start" icon={Refresh01Icon} />
                 Try again
               </Button>

--- a/apps/web/app/(full-layout)/dashboard/_hooks/use-dashboard.ts
+++ b/apps/web/app/(full-layout)/dashboard/_hooks/use-dashboard.ts
@@ -8,25 +8,45 @@ import type { Dashboard } from '../_types/dashboard.types';
 
 const DASHBOARD_ERROR_MESSAGE = 'Unable to load your dashboard.';
 
+interface RefreshDashboardOptions {
+  silent?: boolean;
+}
+
 export function useDashboard() {
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const refreshDashboard = useCallback(async () => {
-    setIsLoading(true);
-    setErrorMessage(null);
+  const refreshDashboard = useCallback(async (options: RefreshDashboardOptions = {}) => {
+    const isSilent = options.silent ?? false;
+
+    if (!isSilent) {
+      setIsLoading(true);
+      setErrorMessage(null);
+    }
 
     try {
       const response = await dashboardService.getDashboard();
       setDashboard(response);
+      setErrorMessage(null);
     } catch {
-      setDashboard(null);
-      setErrorMessage(DASHBOARD_ERROR_MESSAGE);
+      if (!isSilent) {
+        setDashboard(null);
+        setErrorMessage(DASHBOARD_ERROR_MESSAGE);
+      }
     } finally {
-      setIsLoading(false);
+      if (!isSilent) {
+        setIsLoading(false);
+      }
     }
   }, []);
+
+  const updateDashboard = useCallback(
+    (updater: (dashboard: Dashboard | null) => Dashboard | null) => {
+      setDashboard(updater);
+    },
+    [],
+  );
 
   useEffect(() => {
     void refreshDashboard();
@@ -37,5 +57,6 @@ export function useDashboard() {
     errorMessage,
     isLoading,
     refreshDashboard,
+    updateDashboard,
   };
 }

--- a/apps/web/components/layouts/footer.tsx
+++ b/apps/web/components/layouts/footer.tsx
@@ -9,6 +9,7 @@ export function Footer() {
   const pathname = usePathname();
   const shouldHideFooter =
     pathname.startsWith('/dashboard') ||
+    pathname.startsWith('/admin') ||
     pathname.startsWith('/profile') ||
     pathname.startsWith('/roadmaps');
 

--- a/apps/web/components/layouts/header.tsx
+++ b/apps/web/components/layouts/header.tsx
@@ -7,6 +7,7 @@ import {
   Logout02Icon,
   MapsIcon,
   Menu07Icon,
+  SecurityIcon,
   UserCircleIcon,
 } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
@@ -38,6 +39,7 @@ export function Header() {
   const { isAuthenticated, isLoading, signOut, user } = useAuth();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const isAdmin = user?.role === 'ADMIN';
   const userFirstName = user?.fullName?.trim().split(/\s+/)[0];
   const userDisplayName = userFirstName || 'My Profile';
   const userMenuAriaLabel = userFirstName
@@ -84,6 +86,12 @@ export function Header() {
 
   const userMenuContent = (
     <DropdownMenuContent className="w-44" align="end">
+      {isAdmin && (
+        <DropdownMenuItem render={<Link href={'/admin' as Route<string>} />}>
+          <HugeiconsIcon className="size-4" icon={SecurityIcon} />
+          Admin
+        </DropdownMenuItem>
+      )}
       <DropdownMenuItem render={<Link href={'/dashboard' as Route<string>} />}>
         <HugeiconsIcon className="size-4" icon={DashboardBrowsingIcon} />
         Dashboard
@@ -286,6 +294,15 @@ export function Header() {
                       <HugeiconsIcon className="size-4" icon={MapsIcon} />
                       Dashboard
                     </DropdownMenuItem>
+                    {isAdmin && (
+                      <DropdownMenuItem
+                        render={<Link href={'/admin' as Route<string>} />}
+                        onClick={() => setIsMobileMenuOpen(false)}
+                      >
+                        <HugeiconsIcon className="size-4" icon={SecurityIcon} />
+                        Admin
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem
                       render={<Link href={'/profile' as Route<string>} />}
                       onClick={() => setIsMobileMenuOpen(false)}

--- a/apps/web/constants/endpoints.ts
+++ b/apps/web/constants/endpoints.ts
@@ -12,6 +12,9 @@ export const ENDPOINTS = {
     templates: {
       byId: (templateId: string) => `/admin/templates/${templateId}`,
       list: '/admin/templates',
+      nodeById: (templateId: string, nodeId: string) =>
+        `/admin/templates/${templateId}/nodes/${nodeId}`,
+      nodes: (templateId: string) => `/admin/templates/${templateId}/nodes`,
     },
   },
   auth: {

--- a/apps/web/constants/endpoints.ts
+++ b/apps/web/constants/endpoints.ts
@@ -1,6 +1,15 @@
 export const API_BASE_PATH = process.env.NEXT_PUBLIC_API_BASE_PATH ?? '/api/v1';
 
 export const ENDPOINTS = {
+  admin: {
+    skills: {
+      byId: (skillId: string) => `/admin/skills/${skillId}`,
+      list: '/admin/skills',
+      resourceById: (skillId: string, resourceId: number) =>
+        `/admin/skills/${skillId}/resources/${resourceId}`,
+      resources: (skillId: string) => `/admin/skills/${skillId}/resources`,
+    },
+  },
   auth: {
     changePassword: '/auth/password',
     forgotPassword: '/auth/password/forgot',

--- a/apps/web/constants/endpoints.ts
+++ b/apps/web/constants/endpoints.ts
@@ -9,6 +9,10 @@ export const ENDPOINTS = {
         `/admin/skills/${skillId}/resources/${resourceId}`,
       resources: (skillId: string) => `/admin/skills/${skillId}/resources`,
     },
+    templates: {
+      byId: (templateId: string) => `/admin/templates/${templateId}`,
+      list: '/admin/templates',
+    },
   },
   auth: {
     changePassword: '/auth/password',

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -16,7 +16,7 @@ export async function proxy(request: NextRequest) {
   const refreshToken = request.cookies.get('refresh_token')?.value;
   const { pathname, search } = request.nextUrl;
 
-  const protectedRoutes = ['/dashboard', '/profile', '/roadmaps/generate'];
+  const protectedRoutes = ['/admin', '/dashboard', '/profile', '/roadmaps/generate'];
   const authRoutes = ['/sign-in', '/sign-up'];
 
   const isProtectedRoute = protectedRoutes.some((route) => matchesRoute(pathname, route));

--- a/apps/web/services/admin-content.service.ts
+++ b/apps/web/services/admin-content.service.ts
@@ -8,6 +8,10 @@ import type {
   AdminSkillResourcesResponse,
   AdminSkillsListResponse,
   AdminSkillsQuery,
+  AdminTemplate,
+  AdminTemplatePayload,
+  AdminTemplatesListResponse,
+  AdminTemplatesQuery,
   ApiErrorResponse,
 } from '@/types/admin-content';
 
@@ -26,11 +30,27 @@ export const adminContentService = {
     const response = await axiosInstance.post<AdminSkill>(ENDPOINTS.admin.skills.list, payload);
     return response.data;
   },
+  createTemplate: async (payload: AdminTemplatePayload) => {
+    const response = await axiosInstance.post<AdminTemplate>(
+      ENDPOINTS.admin.templates.list,
+      payload,
+    );
+    return response.data;
+  },
   deleteResource: async (skillId: string, resourceId: number) => {
     await axiosInstance.delete<void>(ENDPOINTS.admin.skills.resourceById(skillId, resourceId));
   },
   deleteSkill: async (skillId: string) => {
     await axiosInstance.delete<void>(ENDPOINTS.admin.skills.byId(skillId));
+  },
+  deleteTemplate: async (templateId: string) => {
+    await axiosInstance.delete<void>(ENDPOINTS.admin.templates.byId(templateId));
+  },
+  getTemplate: async (templateId: string) => {
+    const response = await axiosInstance.get<AdminTemplate>(
+      ENDPOINTS.admin.templates.byId(templateId),
+    );
+    return response.data;
   },
   listResources: async (skillId: string) => {
     const response = await axiosInstance.get<AdminSkillResourcesResponse>(
@@ -42,6 +62,15 @@ export const adminContentService = {
     const response = await axiosInstance.get<AdminSkillsListResponse>(ENDPOINTS.admin.skills.list, {
       params: query,
     });
+    return response.data;
+  },
+  listTemplates: async (query: AdminTemplatesQuery) => {
+    const response = await axiosInstance.get<AdminTemplatesListResponse>(
+      ENDPOINTS.admin.templates.list,
+      {
+        params: query,
+      },
+    );
     return response.data;
   },
   updateResource: async (
@@ -58,6 +87,13 @@ export const adminContentService = {
   updateSkill: async (skillId: string, payload: Partial<AdminSkillPayload>) => {
     const response = await axiosInstance.put<AdminSkill>(
       ENDPOINTS.admin.skills.byId(skillId),
+      payload,
+    );
+    return response.data;
+  },
+  updateTemplate: async (templateId: string, payload: AdminTemplatePayload) => {
+    const response = await axiosInstance.put<AdminTemplate>(
+      ENDPOINTS.admin.templates.byId(templateId),
       payload,
     );
     return response.data;

--- a/apps/web/services/admin-content.service.ts
+++ b/apps/web/services/admin-content.service.ts
@@ -1,0 +1,73 @@
+import axios from 'axios';
+
+import type {
+  AdminSkill,
+  AdminSkillPayload,
+  AdminSkillResource,
+  AdminSkillResourcePayload,
+  AdminSkillResourcesResponse,
+  AdminSkillsListResponse,
+  AdminSkillsQuery,
+  ApiErrorResponse,
+} from '@/types/admin-content';
+
+import { ENDPOINTS } from '@/constants/endpoints';
+import { axiosInstance } from '@/lib/axios-instance';
+
+export const adminContentService = {
+  createResource: async (skillId: string, payload: AdminSkillResourcePayload) => {
+    const response = await axiosInstance.post<AdminSkillResource>(
+      ENDPOINTS.admin.skills.resources(skillId),
+      payload,
+    );
+    return response.data;
+  },
+  createSkill: async (payload: AdminSkillPayload) => {
+    const response = await axiosInstance.post<AdminSkill>(ENDPOINTS.admin.skills.list, payload);
+    return response.data;
+  },
+  deleteResource: async (skillId: string, resourceId: number) => {
+    await axiosInstance.delete<void>(ENDPOINTS.admin.skills.resourceById(skillId, resourceId));
+  },
+  deleteSkill: async (skillId: string) => {
+    await axiosInstance.delete<void>(ENDPOINTS.admin.skills.byId(skillId));
+  },
+  listResources: async (skillId: string) => {
+    const response = await axiosInstance.get<AdminSkillResourcesResponse>(
+      ENDPOINTS.admin.skills.resources(skillId),
+    );
+    return response.data;
+  },
+  listSkills: async (query: AdminSkillsQuery) => {
+    const response = await axiosInstance.get<AdminSkillsListResponse>(ENDPOINTS.admin.skills.list, {
+      params: query,
+    });
+    return response.data;
+  },
+  updateResource: async (
+    skillId: string,
+    resourceId: number,
+    payload: AdminSkillResourcePayload,
+  ) => {
+    const response = await axiosInstance.put<AdminSkillResource>(
+      ENDPOINTS.admin.skills.resourceById(skillId, resourceId),
+      payload,
+    );
+    return response.data;
+  },
+  updateSkill: async (skillId: string, payload: Partial<AdminSkillPayload>) => {
+    const response = await axiosInstance.put<AdminSkill>(
+      ENDPOINTS.admin.skills.byId(skillId),
+      payload,
+    );
+    return response.data;
+  },
+};
+
+export function getApiErrorMessage(error: unknown, fallback: string): string {
+  if (!axios.isAxiosError<ApiErrorResponse>(error)) {
+    return fallback;
+  }
+
+  return error.response?.data?.message ?? fallback;
+}

--- a/apps/web/services/admin-content.service.ts
+++ b/apps/web/services/admin-content.service.ts
@@ -9,6 +9,9 @@ import type {
   AdminSkillsListResponse,
   AdminSkillsQuery,
   AdminTemplate,
+  AdminTemplateNode,
+  AdminTemplateNodePayload,
+  AdminTemplateNodesResponse,
   AdminTemplatePayload,
   AdminTemplatesListResponse,
   AdminTemplatesQuery,
@@ -37,6 +40,13 @@ export const adminContentService = {
     );
     return response.data;
   },
+  createTemplateNode: async (templateId: string, payload: AdminTemplateNodePayload) => {
+    const response = await axiosInstance.post<AdminTemplateNode>(
+      ENDPOINTS.admin.templates.nodes(templateId),
+      payload,
+    );
+    return response.data;
+  },
   deleteResource: async (skillId: string, resourceId: number) => {
     await axiosInstance.delete<void>(ENDPOINTS.admin.skills.resourceById(skillId, resourceId));
   },
@@ -45,6 +55,9 @@ export const adminContentService = {
   },
   deleteTemplate: async (templateId: string) => {
     await axiosInstance.delete<void>(ENDPOINTS.admin.templates.byId(templateId));
+  },
+  deleteTemplateNode: async (templateId: string, nodeId: string) => {
+    await axiosInstance.delete<void>(ENDPOINTS.admin.templates.nodeById(templateId, nodeId));
   },
   getTemplate: async (templateId: string) => {
     const response = await axiosInstance.get<AdminTemplate>(
@@ -73,6 +86,12 @@ export const adminContentService = {
     );
     return response.data;
   },
+  listTemplateNodes: async (templateId: string) => {
+    const response = await axiosInstance.get<AdminTemplateNodesResponse>(
+      ENDPOINTS.admin.templates.nodes(templateId),
+    );
+    return response.data;
+  },
   updateResource: async (
     skillId: string,
     resourceId: number,
@@ -94,6 +113,17 @@ export const adminContentService = {
   updateTemplate: async (templateId: string, payload: AdminTemplatePayload) => {
     const response = await axiosInstance.put<AdminTemplate>(
       ENDPOINTS.admin.templates.byId(templateId),
+      payload,
+    );
+    return response.data;
+  },
+  updateTemplateNode: async (
+    templateId: string,
+    nodeId: string,
+    payload: AdminTemplateNodePayload,
+  ) => {
+    const response = await axiosInstance.put<AdminTemplateNode>(
+      ENDPOINTS.admin.templates.nodeById(templateId, nodeId),
       payload,
     );
     return response.data;

--- a/apps/web/types/admin-content.ts
+++ b/apps/web/types/admin-content.ts
@@ -17,6 +17,7 @@ export type RoleCategory =
   | 'WEB_DEVELOPMENT';
 
 export type ResourceType = 'ARTICLE' | 'COURSE' | 'DOCS' | 'YOUTUBE';
+export type TemplateNodeType = 'GROUP' | 'MILESTONE' | 'OPTIONAL' | 'REQUIRED';
 
 export interface AdminSkill {
   createdAt: string;
@@ -76,6 +77,33 @@ export interface AdminTemplatePayload {
   estimatedWeeks?: null | number;
   roleCategory: RoleCategory;
   title: string;
+}
+
+export interface AdminTemplateNode {
+  createdAt: string;
+  description: null | string;
+  estimatedHours: null | number;
+  id: string;
+  name: string;
+  nodeType: TemplateNodeType;
+  parentId: null | string;
+  posX: number;
+  posY: number;
+  roadmapId: string;
+  skillId: null | string;
+}
+
+export interface AdminTemplateNodesResponse {
+  nodes: AdminTemplateNode[];
+}
+
+export interface AdminTemplateNodePayload {
+  description?: null | string;
+  estimatedHours?: null | number;
+  name: string;
+  nodeType: TemplateNodeType;
+  parentId?: null | string;
+  skillId?: null | string;
 }
 
 export interface AdminSkillsQuery {

--- a/apps/web/types/admin-content.ts
+++ b/apps/web/types/admin-content.ts
@@ -38,6 +38,46 @@ export interface AdminSkillsListResponse {
   };
 }
 
+export interface AdminTemplate {
+  deadlineDate: null | string;
+  description: null | string;
+  estimatedWeeks: null | number;
+  generatedAt: string;
+  goalName: null | string;
+  hoursPerDay: null | number;
+  id: string;
+  isTemplate: boolean;
+  roleCategory: RoleCategory;
+  startedAt: null | string;
+  title: string;
+  updatedAt: string;
+  userId: null | string;
+}
+
+export interface AdminTemplatesListResponse {
+  data: AdminTemplate[];
+  meta: {
+    page: number;
+    perPage: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface AdminTemplatesQuery {
+  page?: number;
+  perPage?: number;
+  q?: string;
+  roleCategory?: RoleCategory;
+}
+
+export interface AdminTemplatePayload {
+  description: string;
+  estimatedWeeks?: null | number;
+  roleCategory: RoleCategory;
+  title: string;
+}
+
 export interface AdminSkillsQuery {
   page?: number;
   perPage?: number;

--- a/apps/web/types/admin-content.ts
+++ b/apps/web/types/admin-content.ts
@@ -1,0 +1,84 @@
+export type RoleCategory =
+  | 'ABSOLUTE_BEGINNERS'
+  | 'AI_AND_MACHINE_LEARNING'
+  | 'BEST_PRACTICES'
+  | 'BLOCKCHAIN'
+  | 'COMPUTER_SCIENCE'
+  | 'CYBER_SECURITY'
+  | 'DATA_ANALYSIS'
+  | 'DATABASES'
+  | 'DESIGN'
+  | 'DEVOPS'
+  | 'FRAMEWORKS'
+  | 'GAME_DEVELOPMENT'
+  | 'LANGUAGES_AND_PLATFORMS'
+  | 'MANAGEMENT'
+  | 'MOBILE_DEVELOPMENT'
+  | 'WEB_DEVELOPMENT';
+
+export type ResourceType = 'ARTICLE' | 'COURSE' | 'DOCS' | 'YOUTUBE';
+
+export interface AdminSkill {
+  createdAt: string;
+  defaultEstimatedHours: null | number;
+  description: null | string;
+  id: string;
+  name: string;
+  roleCategory: null | RoleCategory;
+  updatedAt: string;
+}
+
+export interface AdminSkillsListResponse {
+  data: AdminSkill[];
+  meta: {
+    page: number;
+    perPage: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface AdminSkillsQuery {
+  page?: number;
+  perPage?: number;
+  q?: string;
+  roleCategory?: RoleCategory;
+}
+
+export interface AdminSkillPayload {
+  defaultEstimatedHours?: null | number;
+  description?: null | string;
+  name: string;
+  roleCategory: RoleCategory;
+}
+
+export interface AdminSkillResource {
+  createdAt: string;
+  id: number;
+  isFree: boolean;
+  isPrimary: boolean;
+  resourceType: ResourceType;
+  skillId: string;
+  title: string;
+  updatedAt: string;
+  url: string;
+}
+
+export interface AdminSkillResourcesResponse {
+  resources: AdminSkillResource[];
+  skillId: string;
+}
+
+export interface AdminSkillResourcePayload {
+  isFree?: boolean;
+  isPrimary?: boolean;
+  resourceType: ResourceType;
+  title: string;
+  url: string;
+}
+
+export interface ApiErrorResponse {
+  code?: number;
+  errors?: Record<string, string[]>;
+  message?: string;
+}

--- a/apps/web/types/auth.ts
+++ b/apps/web/types/auth.ts
@@ -1,10 +1,12 @@
+export type AuthRole = 'ADMIN' | 'USER';
+
 export interface AuthUser {
   avatarUrl: string;
   createdAt?: string;
   email: string;
   fullName: string;
   id: string;
-  role?: string;
+  role?: AuthRole;
 }
 
 export interface AuthApiUser {
@@ -13,7 +15,7 @@ export interface AuthApiUser {
   email: string;
   fullName: string;
   id: string;
-  role?: string;
+  role?: null | string;
 }
 
 export type OAuthProvider = 'GITHUB' | 'GOOGLE';

--- a/apps/web/utils/user.ts
+++ b/apps/web/utils/user.ts
@@ -1,9 +1,20 @@
-import { type AuthApiUser, type AuthUser } from '@/types/auth';
+import { type AuthApiUser, type AuthRole, type AuthUser } from '@/types/auth';
 
 export function buildDefaultAvatar(seedSource: string) {
   const defaultSource = crypto.randomUUID();
   const seed = encodeURIComponent(seedSource.trim() || defaultSource);
   return `https://api.dicebear.com/10.x/adventurer/svg?seed=${seed}`;
+}
+
+function normalizeRole(role?: null | string): AuthRole | undefined {
+  switch (role?.trim().toUpperCase()) {
+    case 'ADMIN':
+      return 'ADMIN';
+    case 'USER':
+      return 'USER';
+    default:
+      return undefined;
+  }
 }
 
 export function normalizeUser(user: AuthApiUser): AuthUser {
@@ -13,6 +24,6 @@ export function normalizeUser(user: AuthApiUser): AuthUser {
     email: user.email,
     fullName: user.fullName,
     id: user.id,
-    role: user.role,
+    role: normalizeRole(user.role),
   };
 }

--- a/apps/web/validations/admin-content.schema.ts
+++ b/apps/web/validations/admin-content.schema.ts
@@ -20,6 +20,8 @@ export const ROLE_CATEGORY_VALUES = [
 ] as const;
 
 export const RESOURCE_TYPE_VALUES = ['YOUTUBE', 'DOCS', 'COURSE', 'ARTICLE'] as const;
+export const TEMPLATE_NODE_TYPE_VALUES = ['GROUP', 'MILESTONE', 'REQUIRED', 'OPTIONAL'] as const;
+export const TEMPLATE_LEAF_NODE_TYPE_VALUES = ['REQUIRED', 'OPTIONAL'] as const;
 
 export const adminSkillFormSchema = z.object({
   defaultEstimatedHours: z
@@ -59,6 +61,45 @@ export const adminTemplateFormSchema = z.object({
   title: z.string().trim().min(1, 'Template title is required').max(200),
 });
 
+export const adminTemplateNodeFormSchema = z
+  .object({
+    description: z.string().max(2000, 'Description must be 2000 characters or less'),
+    estimatedHours: z
+      .string()
+      .trim()
+      .refine(
+        (value) => value === '' || /^\d+(\.\d{1,2})?$/.test(value),
+        'Use a positive number with up to 2 decimals',
+      )
+      .refine((value) => value === '' || Number(value) <= 9999.99, 'Must be 9999.99 or less'),
+    name: z.string().trim().min(1, 'Node name is required').max(200),
+    nodeType: z.enum(TEMPLATE_NODE_TYPE_VALUES),
+    parentId: z.string(),
+    skillId: z.string(),
+  })
+  .superRefine((values, context) => {
+    const isLeafNode = TEMPLATE_LEAF_NODE_TYPE_VALUES.includes(
+      values.nodeType as (typeof TEMPLATE_LEAF_NODE_TYPE_VALUES)[number],
+    );
+
+    if (isLeafNode && !values.parentId) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Choose a parent section',
+        path: ['parentId'],
+      });
+    }
+
+    if (isLeafNode && !values.skillId) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Choose a skill',
+        path: ['skillId'],
+      });
+    }
+  });
+
 export type AdminResourceFormValues = z.infer<typeof adminResourceFormSchema>;
 export type AdminSkillFormValues = z.infer<typeof adminSkillFormSchema>;
 export type AdminTemplateFormValues = z.infer<typeof adminTemplateFormSchema>;
+export type AdminTemplateNodeFormValues = z.infer<typeof adminTemplateNodeFormSchema>;

--- a/apps/web/validations/admin-content.schema.ts
+++ b/apps/web/validations/admin-content.schema.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const ROLE_CATEGORY_VALUES = [
+  'WEB_DEVELOPMENT',
+  'FRAMEWORKS',
+  'ABSOLUTE_BEGINNERS',
+  'LANGUAGES_AND_PLATFORMS',
+  'DEVOPS',
+  'DATABASES',
+  'COMPUTER_SCIENCE',
+  'DESIGN',
+  'BEST_PRACTICES',
+  'AI_AND_MACHINE_LEARNING',
+  'DATA_ANALYSIS',
+  'MOBILE_DEVELOPMENT',
+  'MANAGEMENT',
+  'GAME_DEVELOPMENT',
+  'BLOCKCHAIN',
+  'CYBER_SECURITY',
+] as const;
+
+export const RESOURCE_TYPE_VALUES = ['YOUTUBE', 'DOCS', 'COURSE', 'ARTICLE'] as const;
+
+export const adminSkillFormSchema = z.object({
+  defaultEstimatedHours: z
+    .string()
+    .trim()
+    .refine(
+      (value) => value === '' || /^\d+(\.\d{1,2})?$/.test(value),
+      'Use a positive number with up to 2 decimals',
+    )
+    .refine((value) => value === '' || Number(value) <= 9999.99, 'Must be 9999.99 or less'),
+  description: z.string().max(2000, 'Description must be 2000 characters or less'),
+  name: z.string().trim().min(1, 'Skill name is required').max(200),
+  roleCategory: z.enum(ROLE_CATEGORY_VALUES),
+});
+
+export const adminResourceFormSchema = z.object({
+  isFree: z.boolean(),
+  isPrimary: z.boolean(),
+  resourceType: z.enum(RESOURCE_TYPE_VALUES),
+  title: z.string().trim().min(1, 'Resource title is required').max(200),
+  url: z
+    .string()
+    .trim()
+    .url('Enter a valid http or https URL')
+    .refine((value) => /^https?:\/\//i.test(value), 'URL must start with http:// or https://'),
+});
+
+export type AdminResourceFormValues = z.infer<typeof adminResourceFormSchema>;
+export type AdminSkillFormValues = z.infer<typeof adminSkillFormSchema>;

--- a/apps/web/validations/admin-content.schema.ts
+++ b/apps/web/validations/admin-content.schema.ts
@@ -47,5 +47,18 @@ export const adminResourceFormSchema = z.object({
     .refine((value) => /^https?:\/\//i.test(value), 'URL must start with http:// or https://'),
 });
 
+export const adminTemplateFormSchema = z.object({
+  description: z.string().trim().min(1, 'Description is required').max(2000),
+  estimatedWeeks: z
+    .string()
+    .trim()
+    .refine((value) => value === '' || /^\d+$/.test(value), 'Use a whole number of weeks')
+    .refine((value) => value === '' || Number(value) >= 1, 'Must be at least 1 week')
+    .refine((value) => value === '' || Number(value) <= 520, 'Must be 520 weeks or less'),
+  roleCategory: z.enum(ROLE_CATEGORY_VALUES),
+  title: z.string().trim().min(1, 'Template title is required').max(200),
+});
+
 export type AdminResourceFormValues = z.infer<typeof adminResourceFormSchema>;
 export type AdminSkillFormValues = z.infer<typeof adminSkillFormSchema>;
+export type AdminTemplateFormValues = z.infer<typeof adminTemplateFormSchema>;


### PR DESCRIPTION
## Description

Add a full admin console accessible to users with the `ADMIN` role, enabling CRUD management of skills (with resources), templates, and template nodes. Includes a dedicated admin layout with sidebar navigation, protected routes, and role-based UI visibility.

## Related Issue

Closes #102

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Improvement (refactor / chore)
- [ ] Documentation

## Changes Made

- **Admin role & auth** — Add `ADMIN` | `USER` role type, normalize role in `normalizeUser()`, show "Admin" nav link in header/dropdown for admin users
- **Admin layout** — New `/admin` layout with sticky sidebar navigation (`Skills`, `Templates`) using `TablerIcons`
- **Skills management** — Full CRUD with paginated listing, search by name, filter by role category, and inline resource management (create/update/delete with max 2 primary enforcement)
- **Templates management** — Full CRUD with paginated listing, search by title, filter by role category, and drawer-based create/edit forms
- **Template node editor** — `/admin/templates/[templateId]` page with dagre-based auto-layout, drawer-based add/edit for GROUP/MILESTONE/REQUIRED/OPTIONAL nodes, skill selection, drag-to-assign parent sections, and cascading delete for sections
- **API support** — Admin endpoints for skills, templates, and template nodes (list/get/create/update/delete) with pagination and query params
- **Validation** — Zod schemas for all admin forms (skills, resources, templates, template nodes)
- **Dashboard optimistic updates** — Optimistic roadmap removal with silent background refresh and rollback on error
- **Misc** — Hide footer on `/admin` routes, add `/admin` to protected route proxy, add `SecurityIcon` to icon imports

## How to Test

1. Sign in as a user with `ADMIN` role
2. Navigate to `/admin` via the "Admin" link in the user menu
3. Create, edit, and delete skills with resources
4. Create, edit, and delete templates with nodes of different types
5. Verify pagination, search, and role category filters work
6. Verify admin routes are protected for non-admin users
7. Verify footer is hidden on admin pages

## Screenshots (if FE)

<details>
<summary><strong>Expand</strong></summary>

<!-- START - Add images here -->
<img width="2048" height="1139" alt="image" src="https://github.com/user-attachments/assets/224bfd13-b453-42b4-aa05-30bba59bdaff" />
<img width="2048" height="1139" alt="image" src="https://github.com/user-attachments/assets/d4885329-10fe-480b-a6ab-5e37bd415893" />
<img width="2048" height="1139" alt="image" src="https://github.com/user-attachments/assets/1564009b-891e-4435-914f-09661553623a" />
<!-- END -->

</details>

## Checklist

- [x] Code compiles and runs
- [x] No console errors
- [x] Follows project conventions
- [x] Self-reviewed

## Notes

The admin console is behind the `ADMIN` role gate — users without this role will not see the admin nav links and will be redirected from `/admin` routes.